### PR TITLE
Issue2

### DIFF
--- a/replab_addpaths.m
+++ b/replab_addpaths.m
@@ -73,9 +73,7 @@ function replab_addpaths(verbose)
         if verbose >= 1
             warning('YALMIP was not found in the path, some functionalities of the library might be disabled');
         end
-    else
-        if verbose >= 2
-            disp('YALMIP is already in the path');
-        end
+    elseif verbose >= 2
+        disp('YALMIP is already in the path');
     end
 end

--- a/replab_addpaths.m
+++ b/replab_addpaths.m
@@ -1,10 +1,81 @@
-function replab_addpaths
-    % Adds directories that are needed to enable all functionalities of the
-    % library to the search path.
+function replab_addpaths(verbose)
+    % replab_addpaths([verbose])
+    %
+    % replab_addpaths adds directories that are needed to the search path
+    % in order to enable all functionalities of the library.
+    %
+    % The optional parameter 'verbose' controls the display level:
+    %   0 only produce a display in case of error
+    %   1 informs of the changes made (default value)
+    %   2 prints the complete information
     
+    
+    %% Parameter checking
+    if nargin < 1
+        verbose = 1;
+    end
+    
+    
+    %% Action
     [pathStr, name, extension] = fileparts(which(mfilename));
     addpath(pathStr);
-    addpath([pathStr '/external/vpi']);
-    addpath([pathStr '/external/MOxUnit/MOxUnit']);
-    addpath([pathStr '/external/MOxUnit/MOxUnit/util']);
+    
+    % Making sure the VPI library is in the path and working
+    VPIInPath = false;
+    try
+        VPIInPath = isequal(num2str(vpi('1234567890098765432100123456789')), '    1234567890098765432100123456789');
+    catch
+    end
+    if ~VPIInPath
+        if exist([pathStr '/external/vpi/@vpi/vpi.m']) ~= 2
+            error(['The VPI library was not found in the folder ', pathStr, '/external/vpi']);
+        else
+            addpath([pathStr '/external/vpi']);
+            if verbose >= 1
+                disp('Adding VPI to the path');
+            end
+        end
+    elseif verbose >= 2
+        disp('VPI is already in the path');
+    end
+    
+    % Making sure MOxUnit is in the path and working
+    MOxUnitInPath = false;
+    try
+        moxunit_set_path;
+        MOxUnitInPath = true;
+    catch
+    end
+    if ~MOxUnitInPath
+        if exist([pathStr '/external/MOxUnit/MOxUnit/moxunit_set_path.m']) ~= 2
+            warning(['The MOxUnit library was not found in the folder ', pathStr, '/external/MOxUnit', char(10), ...
+                'Did you run ''git submodule init'' and ''git submodule update''?', char(10), ...
+                'It will not be possible to run the tests.']);
+        else
+            addpath([pathStr '/external/MOxUnit/MOxUnit']);
+            moxunit_set_path;
+            if verbose >= 1
+                disp('Adding MOxUnit to the path');
+            end
+        end
+    elseif verbose >= 2
+        disp('MOxUnit is already in the path');
+    end
+    
+    % Making sure YALMIP is in the path and working
+    YALMIPInPath = false;
+    try
+        yalmip('version');
+        YALMIPInPath = true;
+    catch
+    end
+    if ~YALMIPInPath
+        if verbose >= 1
+            warning('YALMIP was not found in the path, some functionalities of the library might be disabled');
+        end
+    else
+        if verbose >= 2
+            disp('YALMIP is already in the path');
+        end
+    end
 end

--- a/replab_runtests.m
+++ b/replab_runtests.m
@@ -1,9 +1,22 @@
 function result = replab_runtests
-    % Tests the library functionalities
+    % result = replab_runtests
+    %
+    % replab_runtests tests the library functionalities
     
     initialPath = pwd;
     [pathStr, name, extension] = fileparts(which(mfilename));
     cd(pathStr)
+    
+    % Check the presence of the MOxUnit library
+    MOxUnitInPath = false;
+    try
+        moxunit_set_path;
+        MOxUnitInPath = true;
+    catch
+    end
+    if ~MOxUnitInPath
+        error('The MOxUnit library was not found. Did you run replab_addpaths?')
+    end
     
     result = moxunit_runtests('tests','-verbose');
     


### PR DESCRIPTION
`replab_addpaths` now only adds libraries that are missing. A user can thus work with his favorite version of VPI or MOxUnit.

Moreover, `replab_addpaths` now:
 - provides helpful information for the user in case a library is not found.
 - has a parameter to adjust the desired verbosity level
 - simply disables the test suite if MOxUnit is not in the path
 - also checks for the presence of the YALMIP

This fixes #2 

