### PR TITLE
Cleaner test structure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "MOxUnit"]
 	path = external/MOxUnit
 	url = https://github.com/MOxUnit/MOxUnit.git
-[submodule "external/MOcov"]
+[submodule "MOcov"]
 	path = external/MOcov
-	url = https://github.com/MOcov/MOcov
+	url = https://github.com/MOcov/MOcov.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ install:
 
 ###############################################################################
 before_script:
-  - TEST_ARGS="'-verbose', '-with_coverage', '-cover', '.', '-cover_exclude', 'external', '-cover_exclude', 'tests', '-cover_exclude', 'docs_src', '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html'";
-    TEST_COMMAND="exit(~moxunit_runtests('replab_covered_tests.m', $TEST_ARGS));";
+  - TEST_COMMAND="exit(~replab_runtests(1));";
     echo "TEST_COMMAND| $TEST_COMMAND";
   # Double-check we are still in the right directory
   - pwd
@@ -51,6 +50,5 @@ after_script:
   # Check where we ended up and what's going on where we are
   - pwd
   - ls -alh
-  - cat coverage.json
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 ###############################################################################
 before_script:
-  - TEST_ARGS="'-verbose', '-with_coverage', '-cover', '.', '-cover_exclude', 'external', '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html'";
+  - TEST_ARGS="'-verbose', '-with_coverage', '-cover', '.', '-cover_exclude', 'external', '-cover_exclude', 'tests', '-cover_exclude', 'docs_src', '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html'";
     TEST_COMMAND="exit(~moxunit_runtests('replab_covered_tests.m', $TEST_ARGS));";
     echo "TEST_COMMAND| $TEST_COMMAND";
   # Double-check we are still in the right directory

--- a/replab_addpaths.m
+++ b/replab_addpaths.m
@@ -84,7 +84,6 @@ function replab_addpaths(verbose)
     elseif verbose >= 2
         disp('MOcov is already in the path');
     end
-        addpath([pathStr '/external/MOcov/MOcov']);
 
     
     % Making sure YALMIP is in the path and working

--- a/replab_runtests.m
+++ b/replab_runtests.m
@@ -1,8 +1,16 @@
-function result = replab_runtests
-    % result = replab_runtests
+function result = replab_runtests(withCoverage)
+    % result = replab_runtests([withCoverage])
     %
     % replab_runtests tests the library functionalities
+    %
+    % When the option 'withCoverage' is set to 1, code coverage data is
+    % generated.
     
+    if nargin < 1
+        withCoverage = 0;
+    end
+    
+    % Make sure we are in the current path
     initialPath = pwd;
     [pathStr, name, extension] = fileparts(which(mfilename));
     cd(pathStr)
@@ -18,7 +26,28 @@ function result = replab_runtests
         error('The MOxUnit library was not found. Did you run replab_addpaths?')
     end
     
-    result = moxunit_runtests('tests','-verbose');
+    % Check the presence of the MOcov library if needed
+    if withCoverage == 1
+        MOcovInPath = false;
+        try
+            mocov_get_absolute_path('.');
+            MOcovInPath = true;
+        catch
+        end
+        if ~MOcovInPath
+            error('The MOcov library was not found. Did you run replab_addpaths?')
+        end
+    end
     
+    % calls the relevant test suite
+    if withCoverage == 1
+        result = moxunit_runtests('tests/codeCoverageHelperFunction.m', '-verbose', ...
+            '-with_coverage', '-cover', '.', '-cover_exclude', 'external', '-cover_exclude', 'tests', '-cover_exclude', 'docs_src', ...
+            '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html');
+    else
+        result = moxunit_runtests('tests', '-verbose', '-recursive');
+    end
+    
+    % return to the previous path
     cd(initialPath);
 end

--- a/tests/codeCoverageHelperFunction.m
+++ b/tests/codeCoverageHelperFunction.m
@@ -1,4 +1,10 @@
-function test_suite = replab_covered_tests()
+function test_suite = codeCoverageHelperFunction()
+    % This file is a helper function for replab_runtests.m. To use it, call
+    % 'replab_runtests(1)'.
+    % 
+    % The name of this function should not contain the string "test"
+    % (otherwise, this will trigger an infinite loop of tests).
+    
     try
         test_functions = localfunctions();
     catch
@@ -12,8 +18,9 @@ function test_suite = replab_covered_tests()
     % monitored by MOxUnit.
     % 
     % This file avoids this behavior by defining a test suite which
-    % consists of all tests in the 'tests' folder. This way, calling
-    % MOxUnit on this file will do the following:
+    % consists of all tests in the 'tests' folder (this one is not included
+    % because its name doesn't contain the string 'test'). This way,
+    % calling MOxUnit on this file will do the following:
     % - define a test suite saying that we want to run MOxUnit on all tests
     %   in the 'tests' folder
     % - activate coverage of the source code in the replab package
@@ -23,24 +30,23 @@ function test_suite = replab_covered_tests()
     % - run the tests
     % - finally, collect the coverage result (if requested)
     %
-    % Here is a way to call this file to achieve this:
-    %   moxunit_runtests('test.m', '-verbose', '-with_coverage', '-cover', '.', '-cover_exclude', 'external', '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html')
-    % To rather run all tests without code coverage, use:
-    %   moxunit_runtests('tests', '-recursive', '-verbose', '-junit_xml_file', 'testresults.xml')
+    % This is what happens when calling replab_runtests with code coverage
+    % enabled.
     
-    % At this point it is important to remove the current path so that the
+    % At this point it is important to remove the replab path so that the
     % default location for the source code will be the one with activated
     % coverage
     [pathStr, name, extension] = fileparts(which(mfilename));
-    rmpath(pathStr);
+    replabFolder = pathStr(1:find(pathStr=='/',1,'last')-1);
+    rmpath(replabFolder);
     
     % We define a test which consists of all other tests
     f = @() moxunit_runtests('tests', '-recursive', '-verbose', '-junit_xml_file', 'testresults.xml');
-    testCase = MOxUnitFunctionHandleTestCase('All tests with coverage', pwd, f);
+    testCase = MOxUnitFunctionHandleTestCase('All tests with coverage', replabFolder, f);
     test_suite = addTest(test_suite, testCase);
     
     % We can restore the path
-    addpath(pathStr);
+    addpath(replabFolder);
 end
 
 


### PR DESCRIPTION
Taking advantage of a bug fix in MOxUnit allowing multiple exclusion folders for code covering, to simplify the test structure.

Left out the question of why BSGS code doesn't appear in coverage report yet.