### PR TITLE
Use sparse matrices when convenient, except when dimension is small

### DIFF
--- a/src/+replab/+quantum/GHZ.m
+++ b/src/+replab/+quantum/GHZ.m
@@ -48,11 +48,7 @@ classdef GHZ < replab.semidirectproduct.OfCompactGroups
             nL = self.nLevels;
             partyRho = replab.Permutations.toMatrix(H1.indexRelabelingPermutation(h1, nL));
             levelMat = replab.Permutations.toMatrix(h2);
-            if replab.Settings.useSparse
-                levelRho = sparse(1);
-            else
-                levelRho = 1;
-            end
+            levelRho = replab.sparse_(1);
             for i = 1:self.nParties
                 levelRho = kron(levelRho, levelMat);
             end

--- a/src/+replab/+quantum/GHZBase.m
+++ b/src/+replab/+quantum/GHZBase.m
@@ -45,16 +45,9 @@ classdef GHZBase < replab.CompactGroup
         %
         % Returns:
         %   double matrix: Complex diagonal matrix representation
-            if replab.Settings.useSparse
-                rho = sparse(1);
-            else
-                rho = 1;
-            end
+                rho = replab.sparse_(1);
             for i = 1:self.nParties
-                D = diag(exp(1i*g(i,:)));
-                if replab.Settings.useSparse
-                    D = sparse(D);
-                end
+                D = replab.diag_(exp(1i*g(i,:)));
                 rho = kron(rho, D);
             end
         end

--- a/src/+replab/+quantum/GeneralizedPauli.m
+++ b/src/+replab/+quantum/GeneralizedPauli.m
@@ -98,15 +98,9 @@ classdef GeneralizedPauli < replab.FiniteGroup
         function rep = naturalRep(self)
             omega = self.rootsOfUnity;
             d = self.d;
-            W = diag(omega(2)*ones(1, d));
-            X = sparse([2:d 1], 1:d, ones(1, d));
-            Z = diag(omega);
-            if ~replab.Settings.useSparse
-                X = full(X);
-            else
-                W = sparse(W);
-                Z = sparse(Z);
-            end
+            W = replab.diag_(omega(2)*ones(1, d));
+            X = replab.sparse_([2:d 1], 1:d, ones(1, d));
+            Z = replab.diag_(omega);
             rep = replab.Rep.lambda(self, 'C', d, true, @(g) W^g(1)*X^g(2)*Z^g(3));
         end
 

--- a/src/+replab/+rep/IndexRelabelingRep.m
+++ b/src/+replab/+rep/IndexRelabelingRep.m
@@ -22,10 +22,7 @@ classdef IndexRelabelingRep < replab.Rep
             dims = self.localDimension*ones(1, n);
             I = permute(reshape(1:d, dims), g);
             I = I(:)';
-            rho = sparse(I, 1:d, ones(1, d), d, d);
-            if ~replab.Settings.useSparse
-                rho = full(rho);
-            end
+            rho = replab.sparse_(I, 1:d, ones(1, d), d, d);
         end
         
     end

--- a/src/+replab/+rep/TrivialRep.m
+++ b/src/+replab/+rep/TrivialRep.m
@@ -13,11 +13,7 @@ classdef TrivialRep < replab.Rep
             self.field = field;
             self.dimension = dimension;
             self.isUnitary = true;
-            if replab.Settings.useSparse
-                self.identity = speye(self.dimension);
-            else
-                self.identity = eye(self.dimension);
-            end
+            self.identity = replab.eye_(self.dimension);
         end
         
         %% Rep methods

--- a/src/+replab/+rep/extractTrivial.m
+++ b/src/+replab/+rep/extractTrivial.m
@@ -31,11 +31,7 @@ function [Utrivial Urest] = extractTrivial(rep)
     if size(Utrivial, 2) > 0
         Urest = null(Utrivial');
     else
-        if replab.Settings.useSparse
-            Urest = speye(d);
-        else
-            Urest = eye(d);
-        end
+        Urest = replab.eye_(d);
     end
     assert(size(Utrivial, 1) == d);
     assert(size(Urest, 1) == d);

--- a/src/+replab/+rep/orbitDecomposition.m
+++ b/src/+replab/+rep/orbitDecomposition.m
@@ -10,10 +10,7 @@ function [sub O] = orbitDecomposition(rep)
     for b = 1:n
         block = O.block(b);
         d = length(block);
-        basis = sparse(1:d, block, ones(1, d), d, rep.dimension);
-        if ~replab.Settings.useSparse
-            basis = full(basis);
-        end
+        basis = replab.sparse_(1:d, block, ones(1, d), d, rep.dimension);
         sub{b} = rep.subRepUnitary(basis);
     end
 end

--- a/src/+replab/+signed/Permutations.m
+++ b/src/+replab/+signed/Permutations.m
@@ -152,10 +152,7 @@ classdef Permutations < replab.signed.PermutationGroup
         % S.toMatrix(x) * S.toMatrix(y)
         % where S = SignedPermutations(domainSize)
             n = length(signedPerm);
-            mat = sparse(abs(signedPerm), 1:n, sign(signedPerm), n, n);
-            if ~replab.Settings.useSparse
-                mat = full(mat);
-            end
+            mat = replab.sparse_(abs(signedPerm), 1:n, sign(signedPerm), n, n);
         end
         
         function b = isSignedPermutationMatrix(mat)

--- a/src/+replab/+sym/GeneralLinearMatricesWithInverses.m
+++ b/src/+replab/+sym/GeneralLinearMatricesWithInverses.m
@@ -23,11 +23,7 @@ classdef GeneralLinearMatricesWithInverses < replab.Group
               otherwise
                 error('Unknown field');
             end
-            if replab.Settings.useSparse
-                self.identity = [speye(n) speye(n)];
-            else
-                self.identity = [eye(n) eye(n)];
-            end
+            self.identity = [replab.eye_(n) replab.eye_(n)];
         end
         
         % Str

--- a/src/+replab/+wreathproduct/ImprimitiveRep.m
+++ b/src/+replab/+wreathproduct/ImprimitiveRep.m
@@ -30,10 +30,7 @@ classdef ImprimitiveRep < replab.Rep
             rhos = arrayfun(@(i) self.Arep.image(base{i}), 1:n, 'uniform', 0);
             rho = blkdiag(rhos{:});
             dA = self.Arep.dimension;
-            rho = kron(sparse(h, 1:n, ones(1,n), n, n), speye(dA)) * rho;
-            if ~replab.Settings.useSparse
-                rho = full(rho);
-            end
+            rho = kron(replab.sparse_(h, 1:n, ones(1,n), n, n), replab.eye_(dA)) * rho;
         end
         
     end

--- a/src/+replab/+wreathproduct/PrimitiveRep.m
+++ b/src/+replab/+wreathproduct/PrimitiveRep.m
@@ -36,10 +36,7 @@ classdef PrimitiveRep < replab.Rep
             d = self.dimension;
             I = permute(reshape(1:d, dims), fliplr(n + 1 - h));
             I = I(:)';
-            rho = sparse(I, 1:d, ones(1, d), d, d) * rho;
-            if ~replab.Settings.useSparse
-                rho = full(rho);
-            end
+            rho = replab.sparse_(I, 1:d, ones(1, d), d, d) * rho;
         end
         
     end

--- a/src/+replab/GeneralLinearGroup.m
+++ b/src/+replab/GeneralLinearGroup.m
@@ -15,11 +15,7 @@ classdef GeneralLinearGroup < replab.Group & replab.domain.VectorSpace
             self.field = field;
             self.n = n;
             self.parent = replab.domain.Matrices(field, n, n);
-            if replab.Settings.useSparse
-                self.identity = speye(n);
-            else
-                self.identity = eye(n);
-            end
+            self.identity = replab.eye_(n);
         end
         
         % Str

--- a/src/+replab/GeneralLinearGroupWithInverses.m
+++ b/src/+replab/GeneralLinearGroupWithInverses.m
@@ -15,11 +15,7 @@ classdef GeneralLinearGroupWithInverses < replab.Group & replab.domain.VectorSpa
             self.field = field;
             self.n = n;
             self.parent = replab.domain.Matrices(field, n, n);
-            if replab.Settings.useSparse
-                self.identity = [speye(n) speye(n)];
-            else
-                self.identity = [eye(n) eye(n)];
-            end
+            self.identity = [replab.eye_(n) replab.eye_(n)];
         end
         
         % Str

--- a/src/+replab/OrthogonalGroup.m
+++ b/src/+replab/OrthogonalGroup.m
@@ -14,11 +14,7 @@ classdef OrthogonalGroup < replab.CompactGroup
         function self = OrthogonalGroup(n)
             self.n = n;
             self.parent = replab.domain.Matrices('R', n, n);
-            if replab.Settings.useSparse
-                self.identity = speye(n);
-            else
-                self.identity = eye(n);
-            end
+            self.identity = replab.eye_(n);
         end
         
         %% Str methods

--- a/src/+replab/Permutations.m
+++ b/src/+replab/Permutations.m
@@ -235,10 +235,7 @@ classdef Permutations < replab.PermutationGroup
         % Returns:
         %   The permutation matrix corresponding to `perm`.
             n = length(perm);
-            mat = sparse(perm, 1:n, ones(1, n), n, n);
-            if ~replab.Settings.useSparse
-                mat = full(mat);
-            end
+            mat = replab.sparse_(perm, 1:n, ones(1, n), n, n);
         end
         
         function perm = fromMatrix(mat)

--- a/src/+replab/Settings.m
+++ b/src/+replab/Settings.m
@@ -22,28 +22,29 @@ classdef Settings
             value = AveragingIterations;
         end
         
-        function value = useSparse(newValue)
-        % Gets/sets the flag whether to use sparse matrices when possible
+        function value = sparseCutoff(newValue)
+        % Gets/sets the row/column dimension from which RepLAB uses sparse matrices
         %
-        % The default value is `false`.
+        % The default value is 20. When the matrix is not square, we use the
+        % geometric mean of the dimensions.
         %
         % Warnings:
-        %   This flag should be set once before any computations is made,
+        %   This flag should be changed before computations are made,
         %   as matrix values are cached by RepLAB and those cached values
-        %   not updated when this flag changes.
+        %   not updated when this value changes.
         %
         % Args:
-        %   newValue (logical, optional): New flag value
+        %   newValue (integer, optional): New flag value
         %
         % Returns:
-        %   logical: The current flag value.
-            persistent UseSparse;
+        %   logical: The current value.
+            persistent SparseCutoff;
             if nargin == 1
-                UseSparse = newValue;
-            elseif isempty(UseSparse)
-                UseSparse = false;
+                SparseCutoff = newValue;
+            elseif isempty(SparseCutoff)
+                SparseCutoff = 20;
             end
-            value = UseSparse;
+            value = SparseCutoff;
         end
 
         function value = randomizedSchreierSimsTries(newValue)

--- a/src/+replab/SubRep.m
+++ b/src/+replab/SubRep.m
@@ -60,7 +60,7 @@ classdef SubRep < replab.Rep
         function U = U(self)
         % Returns the basis of this subrepresentation in its parent
             if self.hasCorrection
-                U = diag(self.D0) * self.U0;
+                U = replab.diag_(self.D0) * self.U0;
             else
                 U = self.U0;
             end

--- a/src/+replab/UnitaryGroup.m
+++ b/src/+replab/UnitaryGroup.m
@@ -14,11 +14,7 @@ classdef UnitaryGroup < replab.CompactGroup
         function self = UnitaryGroup(n)
             self.n = n;
             self.parent = replab.domain.Matrices('C', n, n);
-            if replab.Settings.useSparse
-                self.identity = speye(n);
-            else
-                self.identity = eye(n);
-            end
+            self.identity = replab.eye_(n);
         end
         
         %% Str methods

--- a/src/+replab/diag_.m
+++ b/src/+replab/diag_.m
@@ -1,0 +1,18 @@
+function D = diag_(vec)
+% Returns the diagonal matrix with given elements on the diagonal
+%
+% Implements a subset of the functionality of the `diag` Octave/Matlab function.
+%
+% Makes sure to use sparse matrices starting from `replab.Settings.sparseCutoff`.
+% Args:
+%   vec (row vector of double): Diagonal elements
+%
+% Returns:
+%   double matrix: Diagonal matrix
+    d = length(vec);
+    if d >= replab.Settings.sparseCutoff
+        D = sparse(1:d, 1:d, vec);
+    else
+        D = diag(vec);
+    end
+end

--- a/src/+replab/eye_.m
+++ b/src/+replab/eye_.m
@@ -1,0 +1,17 @@
+function I = eye_(d)
+% Returns the identity matrix of a specified dimension 
+%
+% Uses `replab.Settings.sparseCutoff` to decide whether the
+% returned matrix is sparse.
+%
+% Args:
+%   d (integer): Dimension of the matrix
+%
+% Returns:
+%   double matrix: A `d` by `d` identity matrix
+    if d >= replab.Settings.sparseCutoff
+        I = speye(d);
+    else
+        I = eye(d);
+    end
+end

--- a/src/+replab/sparse_.m
+++ b/src/+replab/sparse_.m
@@ -1,0 +1,8 @@
+function S = sparse_(varargin)
+% Wraps the `sparse` Octave/Matlab function such that small matrices are returned dense
+    S = sparse(varargin{:});
+    d = replab.Settings.sparseCutoff;
+    if prod(size(S)) < d*d
+        S = full(S);
+    end
+end


### PR DESCRIPTION
This changes the flag `useSparse` into an integer value `sparseCutoff`.

As a bonus, the sparse/nonsparse logic is limited to 3 functions, and the rest of the code is simplified greatly.