### PR TITLE
(WIP) Easy installation script for external modules

### DIFF
--- a/replab_easy_install.m
+++ b/replab_easy_install.m
@@ -1,106 +1,218 @@
 function exitCode = replab_easy_install
+% Checks if the external dependencies are present, 
+%
+% If everything is setup correctly already, the script does not require user interaction, but will
+% display output on the command line.
+%
+% If dependencies are missing, it will propose to the user to download and install the dependencies,
+% from a ZIP file present in the main replab repository (in the ``externals`` branch).
+% User input is required, in that case the script is interactive.
+%
+% This script asks user confirmation before doing anything.
+%
+%
+% Returns:
+%   integer: 0 if the external dependencies are present now, a positive number indicates an error
+    
     isOctave = logical(exist('OCTAVE_VERSION', 'builtin'));
     scriptPath = mfilename('fullpath');
     [replabPath, ~, ~] = fileparts(scriptPath);
+    
     externalPath = fullfile(replabPath, 'external');
+    switch exist(externalPath)
+      case 7
+        % external directory exists, proceed
+      case 0
+        disp(['The external directory ' externalPath ' is not present.']);
+        disp('This means that the VPI library is missing, and it is present by default in the RepLAB distribution.')
+        disp('This script cannot help. Restart with a fresh copy of RepLAB');
+        exitCode = 1;
+      otherwise
+        error('Path error for external'); 
+    end
+
+    
+    MOcovPath = fullfile(externalPath, 'MOcov');
+    MOcovPathExists = exist(MOcovPath) == 7;
+    MOcovTestPath = fullfile(MOcovPath, 'README.md');
+    MOcovZipPath = fullfile(externalPath, 'MOcov.zip');
+    MOcovInstalled = MOcovPathExists && exist(MOcovTestPath) == 2;
+    
+    MOxUnitPath = fullfile(externalPath, 'MOxUnit');
+    MOxUnitPathExists = exist(externalPath) == 7;
+    MOxUnitTestPath = fullfile(MOxUnitPath, 'README.md');
+    MOxUnitZipPath = fullfile(externalPath, 'MOxUnit.zip');
+    MOxUnitInstalled = MOxUnitPathExists && exist(MOxUnitTestPath) == 2;
+    
+    SDPT3Path = fullfile(externalPath, 'SDPT3');
+    SDPT3PathExists = exist(SDPT3Path) == 7;
+    SDPT3TestPath = fullfile(SDPT3Path, 'README.md');
+    SDPT3ZipPath = fullfile(externalPath, 'SDPT3.zip');
+    SDPT3Installed = SDPT3PathExists && exist(SDPT3TestPath) == 2;
+    
+    YALMIPPath = fullfile(externalPath, 'YALMIP');
+    YALMIPPathExists = exist(YALMIPPath) == 7;
+    YALMIPTestPath = fullfile(YALMIPPath, 'README.md');
+    YALMIPZipPath = fullfile(externalPath, 'YALMIP.zip');
+    YALMIPInstalled = YALMIPPathExists && exist(YALMIPTestPath) == 2;
+
+    if MOcovInstalled && MOxUnitInstalled && SDPT3Installed && YALMIPInstalled
+        disp('All external dependencies are present (or at least their README.md file).');
+        disp('This script is thus not necessary');
+        disp('You can directly run ''replab_addpaths'' to setup the RepLAB path.');
+        exitCode = 0;
+        return
+    end
+    
+    % Test if we are in a Git repository
+    gitPath = fullfile(replabPath, '.git');
+    switch exist(gitPath)
+      case 0
+        % Does not contain a Git directory, proceed
+      case 7
+        % A Git directory exists, bail out
+        disp('This script is designed to streamline the download of external dependencies.');
+        disp(['However, this RepLAB directory ' replabPath ' is a Git repository, so the dependencies']);
+        disp('should be updated using the Git submodule support.');
+        disp('Please run ''git submodule init'' and ''git submodule update'' from the command line');
+        disp('Or download and unzip the latest version without the Git data using the link below:');
+        disp('https://github.com/replab/replab/archive/master.zip');
+        disp('and run this script again.');
+        exitCode = 1;
+        return
+      otherwise
+        error([gitPath ' exists but is not a folder. Restart with a fresh copy of RepLAB.']);
+    end
+    
+    disp('Some dependencies are missing. The script will now download the packages and install them.');
+    s = prompt('Do you wish to proceed [Y/n]?', 's');
+    s = lower(strtrim(s));
+    switch s
+      case {'', 'y'}
+        % proceed
+      case 'n'
+        exitCode = 1;
+        return
+      otherwise
+        error('Unrecognized answer.');
+    end
+    
     zipName = 'replab_externals.zip';
     zipPath = fullfile(replabPath, zipName);
     url = 'https://github.com/replab/replab/raw/externals/replab_externals.zip';
-    MOcovPath = fullfile(externalPath, 'MOcov');
-    MOcovTestPath = fullfile(MOcovPath, 'README.md');
-    MOcovZipPath = fullfile(externalPath, 'MOcov.zip');
-    MOxUnitPath = fullfile(externalPath, 'MOxUnit');
-    MOxUnitTestPath = fullfile(MOxUnitPath, 'README.md');
-    MOxUnitZipPath = fullfile(externalPath, 'MOxUnit.zip');
-    SDPT3Path = fullfile(externalPath, 'SDPT3');
-    SDPT3TestPath = fullfile(SDPT3Path, 'README.md');
-    SDPT3ZipPath = fullfile(externalPath, 'SDPT3.zip');
-    YALMIPPath = fullfile(externalPath, 'YALMIP');
-    YALMIPTestPath = fullfile(YALMIPPath, 'README.md');
-    YALMIPZipPath = fullfile(externalPath, 'YALMIP.zip');
 
-    exitCode = 0;
-    
-    try
-        if exist(zipPath) == 0
-            disp('ZIP file containing externals unavailable, downloading...');
+    switch exist(zipPath)
+      case 0
+        disp('The ZIP file containing externals is not available locally.')
+        disp('You have the option of downloading the file from');
+        disp('https://github.com/replab/replab/raw/externals/replab_externals.zip');
+        disp(['and place it in the root RepLAB folder ' replabPath]);
+        disp('Or we can try to download the file automatically.');
+        disp('After successful installation, this ZIP file can be deleted.');
+        s = prompt('Do you wish to proceed with download [Y/n]?', 's');
+        s = lower(strtrim(s));
+        switch s
+          case {'', 'y'}
+            % proceed
+          case 'n'
+            exitCode = 1;
+            return
+          otherwise
+            error('Unrecognized answer.');
+        end
+        try
             if isOctave
                 [f, success] = urlwrite (url, zipPath);
                 assert(success, 'Download did not work');
             else
                 outfilename = websave(zipPath, url);
             end
-        else
-            disp('ZIP file containing externals found');
+        catch ME
+            disp('Download failed. Download the file manually and restart the script.');
+            exitCode = 1;
+            return
+        end            
+        if exist(zipPath) ~= 2
+            disp('Download failed, file not present. Download the file manually and restart the script.');
+            exitCode = 1;
+            return
         end
-        assert(exist(zipPath) == 2);
         s = dir(zipPath);
-        assert(s.bytes > 1e6, 'Downloaded file is too small');
-        disp('Unzipping');
+        if s.bytes < 1e6
+            disp('Download failed, file is too small. Download the file manually and restart the script.');
+            exitCode = 1;
+            return
+        end
+      case 2
+        % zip file exists, proceed
+        disp(['Externals ZIP file ' zipPath ' available locally.']); 
+        s = dir(zipPath);
+        if s.bytes < 1e6
+            disp('The external ZIP file is too small');
+            exitCode = 1;
+            return
+        end
+      otherwise
+        error('Unrecognized type for the ZIP file path');
+    end
+    
+    disp(['Unzipping ' zipPath]);
+    try
         unzip(zipPath, externalPath);
-        
-        % MOcov
-        if exist(MOcovTestPath) == 2
-            disp('MOcov already present, skipping');
-        else
-            disp('Unzipping MOcov...');
-            unzip(MOcovZipPath, MOcovPath);
-        end
-        
-        % MOxUnit
-
-        if exist(MOxUnitTestPath) == 2
-            disp('MOxUnit already present, skipping');
-        else
-            disp('Unzipping MOxUnit...');
-            unzip(MOxUnitZipPath, MOxUnitPath);
-        end
-        
-        % SDPT3
-
-        if exist(SDPT3TestPath) == 2
-            disp('SDPT3 already present, skipping');
-        else
-            disp('Unzipping SDPT3...');
-            unzip(SDPT3ZipPath, SDPT3Path);
-        end
-        
-        % YALMIP
-
-        if exist(YALMIPTestPath) == 2
-            disp('YALMIP already present, skipping');
-        else
-            disp('Unzipping YALMIP...');
-            unzip(YALMIPZipPath, YALMIPPath);
-        end
-        
     catch ME
-        ME
-        ME.stack
-        disp('Errored');
+        disp('Unzipping failed.')
         exitCode = 1;
+        return
     end
     
+    % MOcov
+    if ~MOcovPathExists
+        disp('Directory MOcovPath not present. Creating.');
+        mkdir(externalPath, 'MOcov');
+    end
+    if MOcovInstalled
+        disp('MOcov already present, skipping');
+    else
+        disp('Unzipping MOcov...');
+        unzip(MOcovZipPath, MOcovPath);
+    end
     
-    disp('Cleaning up ZIP files...')
-    try
-        delete(zipPath);
-    catch ME
+    % MOxUnit
+    if ~MOxUnitPathExists
+        disp('Directory MOxUnit not present. Creating.');
+        mkdir(externalPath, 'MOxUnit');
     end
-    try
-        delete(MOcovZipPath);
-    catch ME
-    end 
-    try
-        delete(MOxUnitZipPath);
-    catch ME
+    if MOxUnitInstalled
+        disp('MOxUnit already present, skipping');
+    else
+        disp('Unzipping MOxUnit...');
+        unzip(MOxUnitZipPath, MOxUnitPath);
     end
-    try
-        delete(SDPT3ZipPath);
-    catch ME
+    
+    % SDPT3
+    if ~SDPT3PathExists
+        disp('Directory SDPT3 not present. Creating.');
+        mkdir(externalPath, 'SDPT3');
     end
-    try
-        delete(YALMIPZipPath);
-    catch ME
+    if SDPT3Installed
+        disp('SDPT3 already present, skipping');
+    else
+        disp('Unzipping SDPT3...');
+        unzip(SDPT3ZipPath, SDPT3Path);
     end
+    
+    % YALMIP
+    if ~YALMIPPathExists
+        disp('Directory YALMIP not present. Creating.');
+        mkdir(externalPath, 'YALMIP');
+    end
+    if YALMIPInstalled
+        disp('YALMIP already present, skipping');
+    else
+        disp('Unzipping YALMIP...');
+        unzip(YALMIPZipPath, YALMIPPath);
+    end
+    
+    exitCode = 0;
 end
+

--- a/replab_easy_install.m
+++ b/replab_easy_install.m
@@ -213,6 +213,8 @@ function exitCode = replab_easy_install
         unzip(YALMIPZipPath, YALMIPPath);
     end
     
+    disp('');
+    disp('Installation successful.');
     exitCode = 0;
 end
 

--- a/replab_easy_install.m
+++ b/replab_easy_install.m
@@ -85,7 +85,7 @@ function exitCode = replab_easy_install
     end
     
     disp('Some dependencies are missing. The script will now download the packages and install them.');
-    s = prompt('Do you wish to proceed [Y/n]?', 's');
+    s = input('Do you wish to proceed [Y/n]?', 's');
     s = lower(strtrim(s));
     switch s
       case {'', 'y'}
@@ -109,7 +109,7 @@ function exitCode = replab_easy_install
         disp(['and place it in the root RepLAB folder ' replabPath]);
         disp('Or we can try to download the file automatically.');
         disp('After successful installation, this ZIP file can be deleted.');
-        s = prompt('Do you wish to proceed with download [Y/n]?', 's');
+        s = input('Do you wish to proceed with download [Y/n]?', 's');
         s = lower(strtrim(s));
         switch s
           case {'', 'y'}

--- a/replab_easy_install.m
+++ b/replab_easy_install.m
@@ -84,7 +84,7 @@ function exitCode = replab_easy_install
         error([gitPath ' exists but is not a folder. Restart with a fresh copy of RepLAB.']);
     end
     
-    disp('Some dependencies are missing. The script will now download the packages and install them.');
+    disp('Some dependencies are missing. The script will now install the missing dependencies.');
     s = input('Do you wish to proceed [Y/n]?', 's');
     s = lower(strtrim(s));
     switch s

--- a/replab_easy_install.m
+++ b/replab_easy_install.m
@@ -1,0 +1,106 @@
+function exitCode = replab_easy_install
+    isOctave = logical(exist('OCTAVE_VERSION', 'builtin'));
+    scriptPath = mfilename('fullpath');
+    [replabPath, ~, ~] = fileparts(scriptPath);
+    externalPath = fullfile(replabPath, 'external');
+    zipName = 'replab_externals.zip';
+    zipPath = fullfile(replabPath, zipName);
+    url = 'https://github.com/replab/replab/raw/externals/replab_externals.zip';
+    MOcovPath = fullfile(externalPath, 'MOcov');
+    MOcovTestPath = fullfile(MOcovPath, 'README.md');
+    MOcovZipPath = fullfile(externalPath, 'MOcov.zip');
+    MOxUnitPath = fullfile(externalPath, 'MOxUnit');
+    MOxUnitTestPath = fullfile(MOxUnitPath, 'README.md');
+    MOxUnitZipPath = fullfile(externalPath, 'MOxUnit.zip');
+    SDPT3Path = fullfile(externalPath, 'SDPT3');
+    SDPT3TestPath = fullfile(SDPT3Path, 'README.md');
+    SDPT3ZipPath = fullfile(externalPath, 'SDPT3.zip');
+    YALMIPPath = fullfile(externalPath, 'YALMIP');
+    YALMIPTestPath = fullfile(YALMIPPath, 'README.md');
+    YALMIPZipPath = fullfile(externalPath, 'YALMIP.zip');
+
+    exitCode = 0;
+    
+    try
+        if exist(zipPath) == 0
+            disp('ZIP file containing externals unavailable, downloading...');
+            if isOctave
+                [f, success] = urlwrite (url, zipPath);
+                assert(success, 'Download did not work');
+            else
+                outfilename = websave(zipPath, url);
+            end
+        else
+            disp('ZIP file containing externals found');
+        end
+        assert(exist(zipPath) == 2);
+        s = dir(zipPath);
+        assert(s.bytes > 1e6, 'Downloaded file is too small');
+        disp('Unzipping');
+        unzip(zipPath, externalPath);
+        
+        % MOcov
+        if exist(MOcovTestPath) == 2
+            disp('MOcov already present, skipping');
+        else
+            disp('Unzipping MOcov...');
+            unzip(MOcovZipPath, MOcovPath);
+        end
+        
+        % MOxUnit
+
+        if exist(MOxUnitTestPath) == 2
+            disp('MOxUnit already present, skipping');
+        else
+            disp('Unzipping MOxUnit...');
+            unzip(MOxUnitZipPath, MOxUnitPath);
+        end
+        
+        % SDPT3
+
+        if exist(SDPT3TestPath) == 2
+            disp('SDPT3 already present, skipping');
+        else
+            disp('Unzipping SDPT3...');
+            unzip(SDPT3ZipPath, SDPT3Path);
+        end
+        
+        % YALMIP
+
+        if exist(YALMIPTestPath) == 2
+            disp('YALMIP already present, skipping');
+        else
+            disp('Unzipping YALMIP...');
+            unzip(YALMIPZipPath, YALMIPPath);
+        end
+        
+    catch ME
+        ME
+        ME.stack
+        disp('Errored');
+        exitCode = 1;
+    end
+    
+    
+    disp('Cleaning up ZIP files...')
+    try
+        delete(zipPath);
+    catch ME
+    end
+    try
+        delete(MOcovZipPath);
+    catch ME
+    end 
+    try
+        delete(MOxUnitZipPath);
+    catch ME
+    end
+    try
+        delete(SDPT3ZipPath);
+    catch ME
+    end
+    try
+        delete(YALMIPZipPath);
+    catch ME
+    end
+end


### PR DESCRIPTION
Added a helper script that downloads the most up to date dependencies from a separate branch (`externals`, containing a single ZIP file named `replab_externals.zip`) on the GitHub repository, and unzips the missing dependencies in `external`.

The script lacks better error handling, and detection of Git submodules (in which case, the user should run the `git submodule update` command instead).

Tested with Octave and Matlab.