### PR TITLE
Fast projection in the commutant

### DIFF
--- a/src/+replab/IrreducibleCommutant.m
+++ b/src/+replab/IrreducibleCommutant.m
@@ -27,6 +27,7 @@ classdef IrreducibleCommutant < replab.Commutant
                 m = iso.multiplicity;
                 cd = iso.copyDimension;
                 if self.irreducible.parent.overC || isequal(first.irrepInfo.divisionAlgebra, 'R')
+                    % Complex representation or real-type real representation
                     block = zeros(m, m);
                     for i = 1:cd
                         block = block + X(shift+(i:cd:d), shift+(i:cd:d));
@@ -34,6 +35,7 @@ classdef IrreducibleCommutant < replab.Commutant
                     block = block/cd;
                     block = kron(block, eye(cd));
                 elseif isequal(first.irrepInfo.divisionAlgebra, 'C')
+                    % Complex-type real representation
                     A = zeros(m, m);
                     B = zeros(m, m);
                     for i = 1:2:cd
@@ -44,6 +46,7 @@ classdef IrreducibleCommutant < replab.Commutant
                     B = B/cd;
                     block = kron(A, eye(cd)) + kron(B, kron(eye(cd/2), [0 -1; 1 0]));
                 else
+                    % Quaternion-type real representation
                     assert(isequal(first.irrepInfo.divisionAlgebra, 'H'));
                     % shape of things that commute with our representation quaternion encoding
                     % [ a -b -c -d

--- a/src/+replab/IrreducibleCommutant.m
+++ b/src/+replab/IrreducibleCommutant.m
@@ -20,8 +20,8 @@ classdef IrreducibleCommutant < replab.Commutant
             I = self.irreducible;
             blocks = {};
             shift = 0;
-            for i = 1:I.nComponents
-                iso = self.irreducible.component(i);
+            for c = 1:I.nComponents
+                iso = self.irreducible.component(c);
                 first = iso.copy(1);
                 d = iso.dimension;
                 m = iso.multiplicity;
@@ -38,7 +38,7 @@ classdef IrreducibleCommutant < replab.Commutant
                     B = zeros(m, m);
                     for i = 1:2:cd
                         A = A + X(shift+(i:cd:d), shift+(i:cd:d)) + X(shift+(i+1:cd:d), shift+(i+1:cd:d));
-                        B = B + X(shift+(i+1:cd:d), shift+(i:cd:d)) - X(shift+(i:cd:d), shift(i+1:cd:d));
+                        B = B + X(shift+(i+1:cd:d), shift+(i:cd:d)) - X(shift+(i:cd:d), shift+(i+1:cd:d));
                     end
                     A = A/cd;
                     B = B/cd;
@@ -78,7 +78,7 @@ classdef IrreducibleCommutant < replab.Commutant
                     block = kron(A, eye(cd)) + kron(B, kron(eye(cd/4), basisB)) + ...
                             kron(C, kron(eye(cd/4), basisC)) + kron(D, kron(eye(cd/4), basisD));
                 end
-                blocks{i} = block;
+                blocks{c} = block;
                 shift = shift + d;
             end
             X1 = blkdiag(blocks{:});

--- a/src/+replab/IrreducibleCommutant.m
+++ b/src/+replab/IrreducibleCommutant.m
@@ -1,0 +1,89 @@
+classdef IrreducibleCommutant < replab.Commutant
+
+    properties (SetAccess = protected)
+        irreducible % replab.Irreducible: Decomposition of the representation into irreducibles
+    end
+    
+    methods
+        
+        function self = IrreducibleCommutant(irreducibleRep)
+        % Constructs the commutant of a irreducible decomposition representation
+        %
+        % Args:
+        %   irreducibleRep (replab.IrreducibleRep): Irreducible decomposition representation
+            assert(isa(irreducibleRep, 'replab.IrreducibleRep'));
+            self = self@replab.Commutant(irreducibleRep);
+            self.irreducible = irreducibleRep.irreducible;
+        end
+        
+        function X1 = project(self, X)
+            I = self.irreducible;
+            blocks = {};
+            shift = 0;
+            for i = 1:I.nComponents
+                iso = self.irreducible.component(i);
+                first = iso.copy(1);
+                d = iso.dimension;
+                m = iso.multiplicity;
+                cd = iso.copyDimension;
+                if self.irreducible.parent.overC || isequal(first.irrepInfo.divisionAlgebra, 'R')
+                    block = zeros(m, m);
+                    for i = 1:cd
+                        block = block + X(shift+(i:cd:d), shift+(i:cd:d));
+                    end
+                    block = block/cd;
+                    block = kron(block, eye(cd));
+                elseif isequal(first.irrepInfo.divisionAlgebra, 'C')
+                    A = zeros(m, m);
+                    B = zeros(m, m);
+                    for i = 1:2:cd
+                        A = A + X(shift+(i:cd:d), shift+(i:cd:d)) + X(shift+(i+1:cd:d), shift+(i+1:cd:d));
+                        B = B + X(shift+(i+1:cd:d), shift+(i:cd:d)) - X(shift+(i:cd:d), shift(i+1:cd:d));
+                    end
+                    A = A/cd;
+                    B = B/cd;
+                    block = kron(A, eye(cd)) + kron(B, kron(eye(cd/2), [0 -1; 1 0]));
+                else
+                    assert(isequal(first.irrepInfo.divisionAlgebra, 'H'));
+                    A = zeros(m, m);
+                    B = zeros(m, m);
+                    C = zeros(m, m);
+                    D = zeros(m, m);
+                    for i = 1:4:cd
+                        A = A + X(shift+(i:cd:d),shift+(i:cd:d)) + X(shift+(i+1:cd:d),shift+(i+1:cd:d)) ...
+                            + X(shift+(i+2:cd:d),shift+(i+2:cd:d)) + X(shift+(i+3:cd:d),shift+(i+3:cd:d));
+                        B = B + X(shift+(i+1:cd:d),shift+(i:cd:d)) - X(shift+(i:cd:d),shift+(i+1:cd:d)) ...
+                            + X(shift+(i+3:cd:d),shift+(i+2:cd:d)) - X(shift+(i+2:cd:d),shift+(i+3:cd:d));
+                        C = C + X(shift+(i+2:cd:d),shift+(i:cd:d)) - X(shift+(i:cd:d),shift+(i+2:cd:d)) ...
+                            + X(shift+(i+1:cd:d),shift+(i+3:cd:d)) - X(shift+(i+3:cd:d),shift+(i+1:cd:d));
+                        D = D + X(shift+(i+3:cd:d),shift+(i:cd:d)) + X(shift+(i+2:cd:d),shift+(i+1:cd:d)) ...
+                            - X(shift+(i+1:cd:d),shift+(i+2:cd:d)) - X(shift+(i:cd:d),shift+(i+3:cd:d));
+                    end
+                    A = A/cd;
+                    B = B/cd;
+                    C = C/cd;
+                    D = D/cd;
+                    basisB = [ 0 -1  0  0
+                               1  0  0  0
+                               0  0  0 -1
+                               0  0  1  0];
+                    basisC = [ 0  0 -1  0
+                               0  0  0  1
+                               1  0  0  0
+                               0 -1  0  0];
+                    basisD = [ 0  0  0 -1
+                               0  0 -1  0
+                               0  1  0  0
+                               1  0  0  0];
+                    block = kron(A, eye(cd)) + kron(B, kron(eye(cd/4), basisB)) + ...
+                            kron(C, kron(eye(cd/4), basisC)) + kron(D, kron(eye(cd/4), basisD));
+                end
+                blocks{i} = block;
+                shift = shift + d;
+            end
+            X1 = blkdiag(blocks{:});
+        end
+        
+    end
+    
+end

--- a/src/+replab/IrreducibleCommutant.m
+++ b/src/+replab/IrreducibleCommutant.m
@@ -45,6 +45,11 @@ classdef IrreducibleCommutant < replab.Commutant
                     block = kron(A, eye(cd)) + kron(B, kron(eye(cd/2), [0 -1; 1 0]));
                 else
                     assert(isequal(first.irrepInfo.divisionAlgebra, 'H'));
+                    % shape of things that commute with our representation quaternion encoding
+                    % [ a -b -c -d
+                    %   b  a  d -c
+                    %   c -d  a  b
+                    %   d  c -b  a]
                     A = zeros(m, m);
                     B = zeros(m, m);
                     C = zeros(m, m);
@@ -53,11 +58,11 @@ classdef IrreducibleCommutant < replab.Commutant
                         A = A + X(shift+(i:cd:d),shift+(i:cd:d)) + X(shift+(i+1:cd:d),shift+(i+1:cd:d)) ...
                             + X(shift+(i+2:cd:d),shift+(i+2:cd:d)) + X(shift+(i+3:cd:d),shift+(i+3:cd:d));
                         B = B + X(shift+(i+1:cd:d),shift+(i:cd:d)) - X(shift+(i:cd:d),shift+(i+1:cd:d)) ...
-                            + X(shift+(i+3:cd:d),shift+(i+2:cd:d)) - X(shift+(i+2:cd:d),shift+(i+3:cd:d));
+                            - X(shift+(i+3:cd:d),shift+(i+2:cd:d)) + X(shift+(i+2:cd:d),shift+(i+3:cd:d));
                         C = C + X(shift+(i+2:cd:d),shift+(i:cd:d)) - X(shift+(i:cd:d),shift+(i+2:cd:d)) ...
-                            + X(shift+(i+1:cd:d),shift+(i+3:cd:d)) - X(shift+(i+3:cd:d),shift+(i+1:cd:d));
-                        D = D + X(shift+(i+3:cd:d),shift+(i:cd:d)) + X(shift+(i+2:cd:d),shift+(i+1:cd:d)) ...
-                            - X(shift+(i+1:cd:d),shift+(i+2:cd:d)) - X(shift+(i:cd:d),shift+(i+3:cd:d));
+                            - X(shift+(i+1:cd:d),shift+(i+3:cd:d)) + X(shift+(i+3:cd:d),shift+(i+1:cd:d));
+                        D = D + X(shift+(i+3:cd:d),shift+(i:cd:d)) - X(shift+(i+2:cd:d),shift+(i+1:cd:d)) ...
+                            + X(shift+(i+1:cd:d),shift+(i+2:cd:d)) - X(shift+(i:cd:d),shift+(i+3:cd:d));
                     end
                     A = A/cd;
                     B = B/cd;
@@ -65,15 +70,15 @@ classdef IrreducibleCommutant < replab.Commutant
                     D = D/cd;
                     basisB = [ 0 -1  0  0
                                1  0  0  0
-                               0  0  0 -1
-                               0  0  1  0];
-                    basisC = [ 0  0 -1  0
                                0  0  0  1
+                               0  0 -1  0];
+                    basisC = [ 0  0 -1  0
+                               0  0  0 -1
                                1  0  0  0
-                               0 -1  0  0];
+                               0  1  0  0];
                     basisD = [ 0  0  0 -1
-                               0  0 -1  0
-                               0  1  0  0
+                               0  0  1  0
+                               0 -1  0  0
                                1  0  0  0];
                     block = kron(A, eye(cd)) + kron(B, kron(eye(cd/4), basisB)) + ...
                             kron(C, kron(eye(cd/4), basisC)) + kron(D, kron(eye(cd/4), basisD));

--- a/src/+replab/IrreducibleRep.m
+++ b/src/+replab/IrreducibleRep.m
@@ -13,7 +13,10 @@ classdef IrreducibleRep < replab.Rep
         % Constructs a representation from an irreducible decomposition
             parent = irreducible.parent;
             assert(isequal(parent.isUnitary, true));
-            self = self@replab.Rep(parent.group, parent.field, parent.dimension);
+            self.group = parent.group;
+            self.field = parent.field;
+            self.dimension = parent.dimension;
+            self.isUnitary = true;
             self.irreducible = irreducible;
         end
         
@@ -39,6 +42,10 @@ classdef IrreducibleRep < replab.Rep
             end
             % Computes the block diagonal basis
             rho = blkdiag(blocks{:});
+        end
+        
+        function c = commutant(self)
+            c = replab.IrreducibleCommutant(self);
         end
         
     end

--- a/src/+replab/Isotypic.m
+++ b/src/+replab/Isotypic.m
@@ -31,6 +31,11 @@ classdef Isotypic < replab.Str
             self.copyDimension = copies{1}.dimension;
         end
         
+        function d = dimension(self)
+        % Returns the dimension of this isotypic component
+            d = self.copyDimension * self.multiplicity;
+        end
+        
         function r = rep(self)
         % Returns the subrepresentation corresponding to this isotypic component
             U = zeros(0, self.parent.dimension);

--- a/tests/CommutantProjectTest.m
+++ b/tests/CommutantProjectTest.m
@@ -1,0 +1,28 @@
+function test_suite = CommutantProjectTest()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+
+function test_quaternion_representations
+    W = replab.S(3).wreathProduct(replab.signed.Permutations.quaternionGroup);
+    rep = W.primitiveRepFun(@(x) x.naturalRep);
+    X = randn(rep.dimension, rep.dimension);
+    I = rep.decomposition;
+    X1 = I.asConjugateRep.commutant.project(X); 
+    X2 = I.asRep.commutant.project(X1);
+    assert(norm(X1 - X2) < replab.Settings.doubleEigTol);
+end
+
+function test_complex_representations
+    C = replab.S(20).cyclicSubgroup;
+    rep = C.naturalRep;
+    X = randn(rep.dimension, rep.dimension);
+    I = rep.decomposition;
+    X1 = I.asConjugateRep.commutant.project(X); 
+    X2 = I.asRep.commutant.project(X1);
+    assert(norm(X1 - X2) < replab.Settings.doubleEigTol);
+end


### PR DESCRIPTION
This implements projection in the commutant, after the decomposition into irreducibles has been done.

```matlab
    C = replab.S(20).cyclicSubgroup;
    rep = C.naturalRep;
    X = randn(rep.dimension, rep.dimension);
    I = rep.decomposition;
    X1 = I.asConjugateRep.commutant.project(X); % original representation with change of basis
    X2 = I.asRep.commutant.project(X1); % synthetic representation from irreducible decomposition
    assert(norm(X1 - X2) < replab.Settings.doubleEigTol);
```

@jdbancal We need something similar for `CommutantVar`. Note the basis for quaternion encoding in the commutant differs from the representation quaternion encoding by signs. No idea why now.