### PR TITLE
subsref computes smaller products

### DIFF
--- a/src/+replab/CommutantVar.m
+++ b/src/+replab/CommutantVar.m
@@ -78,6 +78,7 @@ classdef CommutantVar < replab.Str
             names{1, end+1} = 'blocks';
             names{1, end+1} = 'nComponents';
             names{1, end+1} = 'linearConstraints';
+            names{1, end+1} = 'fullBlockMatrix_';
         end
 
         function [names, values] = additionalFields(self)

--- a/src/+replab/CommutantVar.m
+++ b/src/+replab/CommutantVar.m
@@ -39,6 +39,7 @@ classdef CommutantVar < replab.Str
         dim; % matrix dimension
         blocks; % The sdp blocks corresponding to each irreducible representation
         linearConstraints; % linear constraints imposed on the matrix
+        fullBlockMatrix_; % The combinations, lazy evaluated
     end
 
     methods
@@ -599,6 +600,9 @@ classdef CommutantVar < replab.Str
         % See also:
         %     replab.CommutantVar.headerStr
         
+        % TODO: integrate this function into the interaction with the Str
+        % class
+        
             s = ['SDP matrix of size ', num2str(self.dim), 'x', num2str(self.dim), ' with ', num2str(self.nbVars), ' variables.'];
             s = [s, char(10)];
             s = [s, 'Block structure: '];
@@ -708,6 +712,47 @@ classdef CommutantVar < replab.Str
             end
         end
 
+        function M = fullBlockMatrix(self)
+        % M = fullBlockMatrix(self)
+        %
+        % Returns the full matrix in its block-diagonal form.
+        %
+        % Args:
+        %     self: CommutantVar object
+        %
+        % Returns:
+        %     M: sdpvar matrix in block diagonal form
+        %
+        % Example:
+        %     matrix = replab.CommutantVar.fromPermutations({[2 3 1]})
+        %     see(matrix.fullBlockMatrix)
+            
+            if isempty(self.fullBlockMatrix_)
+                % We construct the matrix for the first time
+                M = sdpvar(1);
+                M(self.dim^2) = 0;
+                M = reshape(M, self.dim*[1 1]);
+                co = 0;
+                for i = 1:self.nComponents
+                    d = self.dimensions1(i);
+                    switch self.types(i)
+                        case 'R'
+                        case 'C'
+                            d = d/2;
+                        case 'H'
+                            d = d/4;
+                        otherwise
+                            error('Unknown type');
+                    end
+                    M(co + (1:d*size(self.blocks{i},1)), co + (1:d*size(self.blocks{i},1))) = kron(self.blocks{i}, eye(d));
+                    co = co + d*size(self.blocks{i},1);
+                end
+                self.fullBlockMatrix_ = M;
+            else
+                M = self.fullBlockMatrix_;
+            end
+        end
+        
         function M = fullMatrix(self)
         % M = fullMatrix(self)
         %
@@ -927,24 +972,7 @@ classdef CommutantVar < replab.Str
                             end
                             
                             % Now we extract only the requested part
-                            M = sdpvar(1);
-                            M(self.dim^2) = 0;
-                            M = reshape(M, self.dim*[1 1]);
-                            co = 0;
-                            for i = 1:self.nComponents
-                                d = self.dimensions1(i);
-                                switch self.types(i)
-                                    case 'R'
-                                    case 'C'
-                                        d = d/2;
-                                    case 'H'
-                                        d = d/4;
-                                    otherwise
-                                        error('Unknown type');
-                                end
-                                M(co + (1:d*size(self.blocks{i},1)), co + (1:d*size(self.blocks{i},1))) = kron(self.blocks{i}, eye(d));
-                                co = co + d*size(self.blocks{i},1);
-                            end
+                            M = self.fullBlockMatrix;
                             if length(varargin{1}.subs{1})*size(self,2) <= size(self,1)*length(varargin{1}.subs{2})
                                 varargout{1} = (self.U(varargin{1}.subs{1},:)*M)*(self.U(varargin{1}.subs{2},:)');
                             else


### PR DESCRIPTION
When requesting only few elements of the SDP matrix, it is not necessary to compute the full product U*M*U': only specific lines of U are needed