### PR TITLE
Installation instructions (ignore SDPT3 untracked files)

### DIFF
--- a/sphinx/tutorials/installation.rst
+++ b/sphinx/tutorials/installation.rst
@@ -53,7 +53,8 @@ Option 2: Clone the library
    `MOxUnit <https://github.com/MOxUnit/MOxUnit>`__, and the tools needed
    for semidefinite programming.
 
-   Ignore the changes in the SDPT3 submodule, for example when compiling MEX files:
+   To ignore changes that will happen when the SDPT3 submodule is compiled,
+   (and thus untracked files are created), run the following command:
 
    ::
 

--- a/sphinx/tutorials/installation.rst
+++ b/sphinx/tutorials/installation.rst
@@ -53,6 +53,15 @@ Option 2: Clone the library
    `MOxUnit <https://github.com/MOxUnit/MOxUnit>`__, and the tools needed
    for semidefinite programming.
 
+   Ignore the changes in the SDPT3 submodule, for example when compiling MEX files:
+
+   ::
+
+      git config submodule.SDPT3.ignore untracked
+
+   or add a ``ignore = untracked`` line to the ``[submodule "SDPT3"]`` section
+   in ``.git/config``.
+
 
 Initializing the library
 ------------------------

--- a/src/replab_release.m
+++ b/src/replab_release.m
@@ -69,9 +69,9 @@ function replab_release
     disp(' ');
     disp('Step 1: Verifying that the current working tree and index are clean');
     [status, cmdout] = system('git diff --exit-code');
-    assert(status == 0, 'The repository has local unstaged changes.');
+    assert(status == 0, 'The repository has local unstaged changes. Verify you followed the installation instructions on the website.');
     [status, cmdout] = system('git diff --cached --exit-code');
-    assert(status == 0, 'The repository has staged but uncommitted changes.');
+    assert(status == 0, 'The repository has staged but uncommitted changes. Verify you followed the installation instructions on the website.');
 
     disp(' ');
     disp('Step 2: Verifying that master and develop branches are in sync with remote origin.');


### PR DESCRIPTION
@jdbancal I updated the Git installation instructions so that `replab_release` can work correctly, ignored the compiled files in the SDPT3 repository (it should have a `.gitignore` directive for that, but that repository is not under our control). Pinging you so that you can update your local config.