### PR TITLE
added excluding file pattern for code coverage

### DIFF
--- a/src/replab_runtests.m
+++ b/src/replab_runtests.m
@@ -93,8 +93,20 @@ function result = replab_runtests(withCoverage, onlyFastTests)
 
     % calls the relevant test suite
     if ReplabTestParameters.withCoverage == 1
-        result = moxunit_runtests('tests/codeCoverageHelperFunction.m', '-verbose', ...
-            '-with_coverage', '-cover', 'src', '-cover_json_file', 'coverage.json', '-cover_xml_file', 'coverage.xml', '-cover_html_dir', 'coverage_html');
+        % Here are the files patterns we don't want to include in the
+        % coverage monitoring. These are checked by MOcov individually in
+        % each subdirectory.
+        patternsToExclude = {'replab_*.m'};
+
+        % We define the test command
+        command = 'moxunit_runtests(''tests/codeCoverageHelperFunction.m'', ''-verbose'', ''-with_coverage'', ''-cover'', ''src'', ''-cover_json_file'', ''coverage.json'', ''-cover_xml_file'', ''coverage.xml'', ''-cover_html_dir'', ''coverage_html''';
+        for i = 1:numel(patternsToExclude)
+            command = [command, ', ''-cover_exclude'', ''', patternsToExclude{i}, ''''];
+        end
+        command = [command, ')']
+
+        % and call it
+        result = eval(command);
     else
         result = moxunit_runtests('tests', '-verbose', '-recursive');
     end


### PR DESCRIPTION
I added a list of files to exclude from the code coverage. Currently, due to https://github.com/MOcov/MOcov/issues/16, this can only be done through generic file patterns (which are applied to all subfolders). Hence we need to have quite specific file patterns (cannot use `src/+replab/file.m` to exclude a single file for example)