### PR TITLE
Faster permutation search

### DIFF
--- a/src/+replab/+bsgs/Chain.m
+++ b/src/+replab/+bsgs/Chain.m
@@ -888,7 +888,7 @@ classdef Chain < replab.Str
         %   l (integer): Level at which to insert the new base point
         %   newBeta (integer): New basis point not part of the current base
             assert(self.isMutable, 'Chain needs to be mutable');
-            assert(~ismember(newBeta, self.B), 'Base point already exists');
+            assert(all(self.B ~= newBeta), 'Base point already exists');
             assert(all(self.S(newBeta, self.Sind(l):end) == newBeta), 'Base point is not redundant');
             n = self.n;
             k = self.length; % previous chain length

--- a/src/+replab/+bsgs/Chain.m
+++ b/src/+replab/+bsgs/Chain.m
@@ -369,6 +369,11 @@ classdef Chain < replab.Str
                     end
                 elseif all(self.S(newBeta, self.Sind(l):end) == newBeta)
                     % the new point is redundant
+                    ind = find(self.B == newBeta);
+                    if ~isempty(ind)
+                        assert(self.orbitSize(ind) == 1); % consistency check
+                        self.removeRedundantBasePoint(ind);
+                    end
                     if removeRedundant
                         % skip this point in newBase
                         i = i + 1;

--- a/src/+replab/+bsgs/ChainWithImages.m
+++ b/src/+replab/+bsgs/ChainWithImages.m
@@ -475,7 +475,7 @@ classdef ChainWithImages < replab.Str
         % Args:
         %   newBeta (integer): New basis point not part of the current basis
             assert(self.isMutable, 'Chain needs to be mutable');
-            assert(~ismember(newBeta, self.B), 'Base point already exists');
+            assert(all(self.B ~= newBeta), 'Base point already exists');
             n = self.n;
             k = self.length; % previous chain length
             self.B = [self.B newBeta];

--- a/src/+replab/+nfg/conjugacyClassesByOrbits.m
+++ b/src/+replab/+nfg/conjugacyClassesByOrbits.m
@@ -18,11 +18,19 @@ function classes = conjugacyClassesByOrbits(group)
     ord = size(I, 2); % group order
     assert(ds < 65536, 'Domain size too big for naive enumeration');
     % we use a simple hash function that maps permutations to doubles
-    % with a domain size < 2^16, that means that if h has values between -1023 and 1023,
-    % the maximal value of the hash is 2^16*(2^16*2^10) = 2^36 which fits in a double
-    h = randi([-1023 1023], 1, ds)-1;
+    % with a domain size < 2^16, that means that if h has values between -2^20+1 and 2^20-1,
+    % the maximal value of the hash is 2^16*(2^16*2^20) = 2^52 which fits in a double
+    h = randi([-2^20+1 2^20-1], 1, ds)-1;
     Ih = h * I;
 
+    % sorts the hash values and the matrix of group elements
+    % so that we can perform a binary search later
+    [~, ind] = sort(Ih);
+    I = I(:, ind);
+    Ih = Ih(:, ind);
+
+    % tests the existence of the binary search built-in
+    has_ismembc2 = exist('ismembc2') > 0;
     nG = group.nGenerators;
     gens = zeros(ds, nG);
     gensInv = zeros(ds, nG);
@@ -45,7 +53,23 @@ function classes = conjugacyClassesByOrbits(group)
                     gen = gens(:,j);
                     genInv = gensInv(:,j);
                     cj = genInv(g(gen)); % faster compose(genInv, g, gen)
-                    f = find(Ih == h*cj);
+                                         % f = ismembc2(h*cj, Ih);
+                    hval = h*cj;
+                    if has_ismembc2
+                        % perform binary search; this function returns the last element
+                        % which matches
+                        last = ismembc2(hval, Ih);
+                        % then we need to find if other elements before match as well
+                        before = last - 1;
+                        while before > 0 && Ih(before) == hval
+                            before = before - 1;
+                        end
+                        f = before+1:last;
+                    else
+                        % fallback on the default find
+                        f = find(Ih == h*cj);
+                    end
+
                     if length(f) > 1
                         % several rows have the same hash, so we look for an exact match
                         loc = replab.util.findRowInMatrix(cj', I(:,f)');

--- a/src/+replab/+nfg/conjugacyClassesByOrbits.m
+++ b/src/+replab/+nfg/conjugacyClassesByOrbits.m
@@ -48,7 +48,7 @@ function classes = conjugacyClassesByOrbits(group)
                     f = find(Ih == h*cj);
                     if length(f) > 1
                         % several rows have the same hash, so we look for an exact match
-                        [~, loc] = ismember(cj', I(:,f)', 'rows');
+                        loc = replab.util.findRowInMatrix(cj', I(:,f)');
                         f = f(loc);
                     end
                     if conjcl(f) == 0

--- a/src/+replab/+util/findRowInMatrix.m
+++ b/src/+replab/+util/findRowInMatrix.m
@@ -1,0 +1,37 @@
+function ind = findRowInMatrix(row, matrix)
+% Finds the rows of a matrix that match a given row
+%
+% Args:
+%   row (double(1, n)): Row vector to match
+%   matrix (double(\*, n)): Matrix to search
+%
+% Returns:
+%   integer(1,\*): Row indices that match
+    if isempty(matrix)
+        ind = [];
+        return
+    end
+
+    ind = find(matrix(:, 1) == row(1))';
+    nCols = size(matrix, 2);
+    for c = 2:nCols
+        ind = ind(matrix(ind, c) == row(c));
+        switch length(ind)
+          case 0
+            return
+          case 1
+            if any(matrix(ind, c+1:end) ~= row(c+1:end))
+                ind = [];
+            end
+            return
+          case 2
+            if any(matrix(ind(2), c+1:end) ~= row(c+1:end))
+                ind = ind(1);
+            end
+            if any(matrix(ind(1), c+1:end) ~= row(c+1:end))
+                ind = ind(2:end);
+            end
+            return
+        end
+    end
+end

--- a/src/+replab/PermutationGroupLeftCosets.m
+++ b/src/+replab/PermutationGroupLeftCosets.m
@@ -87,8 +87,9 @@ classdef PermutationGroupLeftCosets < replab.LeftCosets
                 img = zeros(1, n);
                 for j = 1:n
                     gt = self.canonicalRepresentative(g(T(j,:)));
-                    [ok, loc] = ismember(gt, T, 'rows');
-                    assert(ok);
+                    loc = replab.util.findRowInMatrix(gt, T);
+                    % [ok, loc] = ismember(gt, T, 'rows');
+                    assert(length(loc) == 1);
                     img(j) = loc;
                 end
                 images{i} = img;


### PR DESCRIPTION
We use two strategies.

1. In general, `ismember(A, B, 'rows')` is extremely slow. We introduce a function `replab.util.findRowInMatrix` that is much faster.

2. When the expected list of elements is large, as in the computation for conjugacy classes, we use a simple multiplicative hash of the permutation -- that was already done. However, the search in the hash vector scales in `O(n)`. Now, we instead sort this hash vector once, and we perform lookups using a binary search. For the binary search, we use the Matlab builtin `ismembc2`. We keep a slow path available for Octave as Octave doesn't have the `ismembc2` function.