### PR TITLE
RepByImages preserves sparsity by having sparse identity matrix

### DIFF
--- a/src/+replab/GeneralLinearGroup.m
+++ b/src/+replab/GeneralLinearGroup.m
@@ -27,9 +27,9 @@ classdef GeneralLinearGroup < replab.Group & replab.domain.VectorSpace
             end
             self.sparse = sparse;
             if sparse
-                self.identity = [speye(n) speye(n)];
+                self.identity = speye(n);
             else
-                self.identity = [eye(n) eye(n)];
+                self.identity = eye(n);
             end
         end
 

--- a/src/+replab/GeneralLinearGroup.m
+++ b/src/+replab/GeneralLinearGroup.m
@@ -3,7 +3,8 @@ classdef GeneralLinearGroup < replab.Group & replab.domain.VectorSpace
 
     properties
         n % integer: size
-    end
+        sparse % (logical): Whether to preserve sparse matrices
+     end
 
     properties (Access = protected)
         parent % replab.domain.Matrices: General, not necessarily invertible matrices
@@ -11,11 +12,25 @@ classdef GeneralLinearGroup < replab.Group & replab.domain.VectorSpace
 
     methods
 
-        function self = GeneralLinearGroup(field, n)
+        function self = GeneralLinearGroup(field, n, sparse)
+        % Constructs the group of general linear matrices
+        %
+        % Args:
+        %   field ('R' or 'C'): Real or complex matrices
+        %   n (integer): Size of the square matrices
+        %   sparse (logical, optional): Whether to preserve sparse matrices, default value false
             self.field = field;
             self.n = n;
             self.parent = replab.domain.Matrices(field, n, n);
-            self.identity = eye(n);
+            if nargin < 3
+                sparse = false;
+            end
+            self.sparse = sparse;
+            if sparse
+                self.identity = [speye(n) speye(n)];
+            else
+                self.identity = [eye(n) eye(n)];
+            end
         end
 
         % Str

--- a/src/+replab/GeneralLinearGroupWithInverses.m
+++ b/src/+replab/GeneralLinearGroupWithInverses.m
@@ -3,6 +3,7 @@ classdef GeneralLinearGroupWithInverses < replab.Group & replab.domain.VectorSpa
 
     properties
         n % (integer): Size of the square matrices
+        sparse % (logical): Whether to preserve sparse matrices
     end
 
     properties (Access = protected)
@@ -11,11 +12,25 @@ classdef GeneralLinearGroupWithInverses < replab.Group & replab.domain.VectorSpa
 
     methods
 
-        function self = GeneralLinearGroupWithInverses(field, n)
+        function self = GeneralLinearGroupWithInverses(field, n, sparse)
+        % Constructs the group of general linear matrices, storing inverses
+        %
+        % Args:
+        %   field ('R' or 'C'): Real or complex matrices
+        %   n (integer): Size of the square matrices
+        %   sparse (logical, optional): Whether to preserve sparse matrices, default value false
             self.field = field;
             self.n = n;
             self.parent_ = replab.domain.Matrices(field, n, n);
-            self.identity = [eye(n) eye(n)];
+            if nargin < 3
+                sparse = false;
+            end
+            self.sparse = sparse;
+            if sparse
+                self.identity = [speye(n) speye(n)];
+            else
+                self.identity = [eye(n) eye(n)];
+            end
         end
 
         % Str

--- a/src/+replab/OrthogonalGroup.m
+++ b/src/+replab/OrthogonalGroup.m
@@ -3,6 +3,7 @@ classdef OrthogonalGroup < replab.CompactGroup
 
     properties
         n % integer: Dimension of the orthogonal group
+        sparse % (logical): Whether to preserve sparse matrices
     end
 
     properties (Access = protected)
@@ -11,10 +12,17 @@ classdef OrthogonalGroup < replab.CompactGroup
 
     methods
 
-        function self = OrthogonalGroup(n)
+        function self = OrthogonalGroup(n, sparse)
             self.n = n;
             self.parent = replab.domain.Matrices('R', n, n);
-            self.identity = eye(n);
+            if n < 2
+                sparse = false;
+            end
+            if sparse
+                self.identity = speye(n);
+            else
+                self.identity = eye(n);
+            end
         end
 
         %% Str methods

--- a/src/+replab/OrthogonalGroup.m
+++ b/src/+replab/OrthogonalGroup.m
@@ -15,7 +15,7 @@ classdef OrthogonalGroup < replab.CompactGroup
         function self = OrthogonalGroup(n, sparse)
             self.n = n;
             self.parent = replab.domain.Matrices('R', n, n);
-            if n < 2
+            if nargin < 2
                 sparse = false;
             end
             if sparse

--- a/src/+replab/RepByImages.m
+++ b/src/+replab/RepByImages.m
@@ -67,16 +67,16 @@ classdef RepByImages < replab.Rep
                 generators = self.group.niceGroup.generators;
                 if self.isUnitary
                     if self.overR
-                        target = replab.OrthogonalGroup(d);
+                        target = replab.OrthogonalGroup(d, true);
                     else
-                        target = replab.UnitaryGroup(d);
+                        target = replab.UnitaryGroup(d, true);
                     end
                     symToDouble = replab.Morphism.lambda(target, target, @(X) double(X)); % remove symbolic toolbox stuff
                     self.chain_ = replab.bsgs.ChainWithImages.make(n, target, generators, self.images_internal, ...
                                                                    symToDouble, [], order);
                 else
-                    target1 = replab.GeneralLinearGroupWithInverses(self.field, self.dimension);
-                    target2 = replab.GeneralLinearGroup(self.field, self.dimension);
+                    target1 = replab.GeneralLinearGroupWithInverses(self.field, self.dimension, true);
+                    target2 = replab.GeneralLinearGroup(self.field, self.dimension, true);
                     cut = replab.Morphism.lambda(target1, target2, @(X) double(X(:, 1:self.dimension)));
                     nG = self.group.nGenerators;
                     images = cell(1, nG);

--- a/src/+replab/RepByImages.m
+++ b/src/+replab/RepByImages.m
@@ -61,24 +61,31 @@ classdef RepByImages < replab.Rep
 
         function c = chain(self)
             if isempty(self.chain_)
+                nG = self.group.nGenerators;
+                useSparse = true;
+                for i = 1:nG
+                    if isa(self.images_internal{i}, 'sym') || isa(self.inverseImages_internal{i}, 'sym')
+                        useSparse = false;
+                        break
+                    end
+                end
                 d = self.dimension;
                 n = self.group.niceGroup.domainSize;
                 order = self.group.order;
                 generators = self.group.niceGroup.generators;
                 if self.isUnitary
                     if self.overR
-                        target = replab.OrthogonalGroup(d, true);
+                        target = replab.OrthogonalGroup(d, useSparse);
                     else
-                        target = replab.UnitaryGroup(d, true);
+                        target = replab.UnitaryGroup(d, useSparse);
                     end
                     symToDouble = replab.Morphism.lambda(target, target, @(X) double(X)); % remove symbolic toolbox stuff
                     self.chain_ = replab.bsgs.ChainWithImages.make(n, target, generators, self.images_internal, ...
                                                                    symToDouble, [], order);
                 else
-                    target1 = replab.GeneralLinearGroupWithInverses(self.field, self.dimension, true);
-                    target2 = replab.GeneralLinearGroup(self.field, self.dimension, true);
+                    target1 = replab.GeneralLinearGroupWithInverses(self.field, self.dimension, useSparse);
+                    target2 = replab.GeneralLinearGroup(self.field, self.dimension, useSparse);
                     cut = replab.Morphism.lambda(target1, target2, @(X) double(X(:, 1:self.dimension)));
-                    nG = self.group.nGenerators;
                     images = cell(1, nG);
                     for i = 1:nG
                         images{i} = [self.images_internal{i} self.inverseImages_internal{i}];

--- a/src/+replab/SubRep.m
+++ b/src/+replab/SubRep.m
@@ -105,11 +105,11 @@ classdef SubRep < replab.Rep
 % $$$         end
 
         function rho = image_internal(self, g)
-            rho = full(self.E_internal*self.parent.image_internal(g)*self.B_internal);
+            rho = self.E_internal*self.parent.image_internal(g)*self.B_internal;
         end
 
         function rho = inverseImage_internal(self, g)
-            rho = full(self.E_internal*self.parent.inverseImage_internal(g)*self.B_internal);
+            rho = self.E_internal*self.parent.inverseImage_internal(g)*self.B_internal;
         end
 
     end

--- a/src/+replab/UnitaryGroup.m
+++ b/src/+replab/UnitaryGroup.m
@@ -20,7 +20,7 @@ classdef UnitaryGroup < replab.CompactGroup
         %   sparse (logical, optional): Whether to preserve sparse matrices, default value false
             self.n = n;
             self.parent = replab.domain.Matrices('C', n, n);
-            if n < 2
+            if nargin < 2
                 sparse = false;
             end
             if sparse

--- a/src/+replab/UnitaryGroup.m
+++ b/src/+replab/UnitaryGroup.m
@@ -2,7 +2,8 @@ classdef UnitaryGroup < replab.CompactGroup
 % Describes the group of n x n unitary (complex) matrices
 
     properties
-        n % integer: Dimension of the unitary group
+        n % (integer): Dimension of the unitary group
+        sparse % (logical): Whether to preserve sparse matrices
     end
 
     properties (Access = protected)
@@ -11,10 +12,22 @@ classdef UnitaryGroup < replab.CompactGroup
 
     methods
 
-        function self = UnitaryGroup(n)
+        function self = UnitaryGroup(n, sparse)
+        % Constructs the unitary group
+        %
+        % Args:
+        %   n (integer): Size of the ``n x n`` matrices
+        %   sparse (logical, optional): Whether to preserve sparse matrices, default value false
             self.n = n;
             self.parent = replab.domain.Matrices('C', n, n);
-            self.identity = eye(n);
+            if n < 2
+                sparse = false;
+            end
+            if sparse
+                self.identity = speye(n);
+            else
+                self.identity = eye(n);
+            end
         end
 
         %% Str methods

--- a/tests/replab/RepByImagesTest.m
+++ b/tests/replab/RepByImagesTest.m
@@ -20,3 +20,14 @@ function test_symbolic
     img2 = [1 1; 1 -1]/s2;
     assert(norm(double(img1) - double(img2)) == 0);
 end
+
+function test_stays_sparse
+    S3 = replab.PermutationGroup.of([2 3 1], [2 1 3]);
+    M1 = sparse([0 0 1; 1 0 0; 0 1 0]);
+    M2 = sparse([0 1 0; 1 0 0; 0 0 1]);
+    rep = S3.repByImages('R', 3, {M1 M2}, {M1' M2'});
+    for i = 1:5
+        I = rep.image_internal(S3.sample);
+        assert(issparse(I));
+    end
+end


### PR DESCRIPTION
Fixes #285 