### PR TITLE
Let MATLAB original help function handle the replab_init argument

### DIFF
--- a/src/help_overload/help.m
+++ b/src/help_overload/help.m
@@ -65,7 +65,7 @@ function help(varargin)
                 contents = replab.infra.repl.callOriginalHelp(arg, varName, varValue);
             end
         else
-            if replab.compat.startsWith(arg, 'replab')
+            if replab.compat.startsWith(arg, 'replab') && ~isequal(arg, 'replab_init')
                 contents = replab.infra.repl.lookupHelp(helpFunctionName, fullMode, arg);
             else
                 contents = replab.infra.repl.callOriginalHelp(arg);


### PR DESCRIPTION
Fixes #312

The rationale behind *not* handling `replab_init` using our own framework: it would introduce different root folders for the code base parsing, and I'm not prepared to do that.

The alternative is to "fake" the presence of a `replab_init.m` file in the `src/` folder, but that may introduce problems when there are parse errors and we provide the path to the file.