### PR TITLE
Permutation sets

### DIFF
--- a/src/+replab/+indf/FiniteGroupIndexedFamily.m
+++ b/src/+replab/+indf/FiniteGroupIndexedFamily.m
@@ -5,89 +5,48 @@ classdef FiniteGroupIndexedFamily < replab.IndexedFamily
 
     properties (SetAccess = protected)
         isomorphism % (`+replab.FiniteIsomorphism`): Isomorphism to a permutation group
-        matrix % (integer(\*,\*)): Elements stored as column vectors
-        seed % integer(1, \*): Vector used to hash a permutation
-        perm % integer(1, \*): Permutation of the columns of `.matrix`
-        hash % integer(1, \*): Sorted hash vector ``= seed * matrix(:, perm)``
+        permSet % (`+replab.+perm.Set`): Underlying set of permutations
     end
 
     methods
 
         function self = FiniteGroupIndexedFamily(matrix, isomorphism)
+        % Constructs an indexed family of finite group elements
+        %
+        % Args:
+        %   matrix (domainSize,\*): Matrix of permutation realizations
+        %   isomorphism (`+replab.FiniteIsomorphism`, optional): Isomorphism to a permutation group
             ds = size(matrix, 1);
-
             if nargin < 2
                 isomorphism = [];
             end
-            self.size = vpi(size(matrix, 2));
-            self.matrix = matrix;
-            if ~isempty(matrix)
-                ds = size(matrix, 1);
-                n = size(matrix, 2);
-                r = floor(2^52/n/n) - 1;
-                % we use a simple hash function that maps permutations to doubles
-                % with a domain size < 2^16, that means that if h has values between -2^20+1 and 2^20-1,
-                % the maximal value of the hash is 2^16*(2^16*2^20) = 2^52 which fits in a double
-                seed = randi([-r r], 1, ds)-1;
-                unsortedHash = seed * matrix;
-                [hash, perm] = sort(unsortedHash);
-                invPerm = zeros(1, n);
-                invPerm(perm) = 1:n;
-                self.seed = seed;
-                self.perm = perm;
-                self.hash = hash;
-            end
+            ps = replab.perm.Set(ds);
+            ps.insert(matrix);
+            self.permSet = ps;
+            self.isomorphism = isomorphism;
         end
 
         function obj = at(self, ind)
-            obj = self.matrix(:, ind)';
+            obj = self.permSet.at(ind)';
             if ~isempty(self.isomorphism)
                 obj = self.isomorphism.preimageElement(obj);
             end
         end
 
         function ind = find(self, obj)
-            if isempty(self.matrix)
-                ind = vpi(0);
-                return
-            end
             if ~isempty(self.isomorphism)
                 obj = self.isomorphism.imageElement(obj);
             end
-            hash = self.hash;
-            h = self.seed * obj(:);
-            if exist('ismembc2') > 0;
-                % perform binary search; this function returns the last element which matches
-                last = ismembc2(h, hash);
-                % then we need to find if other elements before match as well
-                before = last - 1;
-                while before > 0 && hash(before) == h
-                    before = before - 1;
-                end
-                f = before+1:last;
-            else
-                f = find(hash == h);
-            end
-            ind = self.perm(f);
-            if length(ind) > 1
-                % several rows have the same hash, so we look for an exact match
-                loc = replab.util.findRowInMatrix(obj, self.matrix(:,ind)');
-                ind = ind(loc);
-            end
-            if length(ind) == 1
-                if ~isequal(obj, self.matrix(:,ind)')
-                    ind = vpi(0);
-                end
-            end
+            ind = self.permSet.find(obj');
         end
 
         function C = toCell(self)
-            matrix = self.matrix;
+            matrix = self.permSet.matrix;
             isomorphism = self.isomorphism;
             if isempty(self.isomorphism)
-                C = arrayfun(@(i) self.matrix(:,i)', 1:size(matrix,2), 'uniform', 0);
+                C = arrayfun(@(i) matrix(:,i)', 1:size(matrix,2), 'uniform', 0);
             else
-                C = arrayfun(@(i) self.isomorphism.preimageElement(self.matrix(:,i)'), 1:size(matrix,2), 'uniform', 0);
+                C = arrayfun(@(i) self.isomorphism.preimageElement(matrix(:,i)'), 1:size(matrix,2), 'uniform', 0);
             end
         end
 

--- a/src/+replab/+perm/Set.m
+++ b/src/+replab/+perm/Set.m
@@ -1,0 +1,209 @@
+classdef Set < replab.Str
+% Stores a set of permutations
+%
+% This is not a multiset; permutations are stored only once, and the implementation is mutable.
+%
+% Those permutations are stored, not necessarily ordered, as columns in a matrix.
+% In parallel, we compute a hash of each of those permutations, and we stored
+% a sorted list of hash values, and the relation between the ordering of permutations
+% in this sorted and the ordering in the matrix of permutations.
+%
+% This enables the use of fast vectorized operations in Matlab while retrieving elements.
+
+    properties
+        domainSize % (integer): Size of the stored permutations
+        matrix % (integer(domainSize,size)): Elements stored as column vectors
+        seed % integer(1,domainSize): Vector used to hash a permutation
+        perm % integer(1,size): Permutation of the columns of `.matrix`
+        hash % integer(1,size): Sorted hash vector ``= seed * matrix(:, perm)``
+    end
+
+    methods
+
+        function self = Set(domainSize)
+            self.domainSize = domainSize;
+            self.matrix = zeros(domainSize, 0);
+            % we use a simple hash function that maps permutations to doubles
+            % we want that ``seed * perm``, is an integer that fits in a double
+            % if the seed coefficients have range in ``[-r, r]``, then the resulting hash
+            % is in ``[-r*domainSize^2, r*domainSize^2]``
+            r = floor(2^52/domainSize/domainSize) - 1;
+            self.seed = randi([-r r], 1, domainSize);
+            self.perm = zeros(1, 0);
+            self.hash = zeros(1, 0);
+        end
+
+        function check(self)
+        % Checks the consistency of internal data structures
+            assert(isequal(self.hash, self.seed * self.matrix(:, self.perm)));
+        end
+
+        function s = size(self)
+        % Returns the number of elements in this set
+            s = size(self.matrix, 2);
+        end
+
+        function permutations = at(self, inds)
+        % Returns the permutations at the given indices
+        %
+        % Args:
+        %   inds (integer(1,\*)): Indices to retrieve
+        %
+        % Returns:
+        %   integer(domainSize,\*): Permutations as column vectors
+            permutations = self.matrix(:, inds);
+        end
+
+        function sort(self)
+        % Sorts the set
+            [matrix1, ind] = sortrows(self.matrix');
+            matrix1 = matrix1';
+            % matrix1 = matrix(:,ind)
+            % hash = seed * matrix(:, perm)
+            % hash = seed * matrix1(:, perm1)
+            % hash = seed * matrix(:, ind(perm1))
+            % thus perm = ind(perm1) which is perm = ind * perm1, perm1 = indInv * perm
+            % perm1 = indInv(perm)
+            n = length(ind);
+            indInv = zeros(1, n);
+            indInv(ind) = 1:n;
+            perm1 = indInv(self.perm);
+            self.matrix = matrix1;
+            self.perm = perm1;
+            % hash doesn't change
+        end
+
+        function inds = insert(self, permutations)
+        % Inserts the given permutations in the set
+        %
+        % Modifies the set in place.
+        %
+        % Args:
+        %   permutations (integer(domainSize,\*)): New permutations to insert, must not be already present
+        %
+        % Returns:
+        %   integer(1,\*): Indices of the inserted permutations
+            unhash = zeros(1, self.size); % unsorted hash
+            unhash(self.perm) = self.hash;
+            addHash = self.seed*permutations;
+            unhash1 = [unhash addHash]; % new unsorted hash
+            matrix1 = [self.matrix permutations];
+            assert(isequal(unhash1, self.seed * matrix1));
+            [hash1, perm1] = sort(unhash1);
+            oldSize = self.size;
+            self.matrix = matrix1;
+            self.perm = perm1;
+            self.hash = hash1;
+            inds = oldSize+1:self.size;
+        end
+
+        function ind = findElement(self, col, range)
+        % Returns the index of the given column, or 0 if not found
+        %
+        % Args:
+        %   col (integer(\*,1)): Integer vector
+        %   range (integer(1,\*), optional): Range in which to search for the element
+        %
+        % Returns:
+        %   integer: Column index, or ``0`` if not found
+            if isempty(self.matrix)
+                ind = 0;
+                return
+            end
+            if nargin < 3 || isempty(range)
+                ind = find(self.matrix(1,:) == col(1));
+            else
+                ind = range(self.matrix(1, range) == col(1));
+            end
+            nr = size(self.matrix, 1);
+            for r = 2:nr
+                switch length(ind)
+                  case 0
+                    return
+                  case 1
+                    if any(self.matrix(r:end, ind) ~= col(r:end))
+                        ind = 0;
+                    end
+                    return
+                  case 2
+                    if all(self.matrix(r:end, ind(1)) == col(r:end))
+                        ind = ind(1);
+                    elseif all(self.matrix(r:end, ind(2)) == col(r:end))
+                        ind = ind(2);
+                    else
+                        ind = 0;
+                    end
+                    return
+                  otherwise
+                    ind = range(self.matrix(r, ind) == col(r));
+                end
+            end
+        end
+
+
+        function inds = find(self, permutations)
+        % Returns the indices of the given permutations, or 0 if not found
+        %
+        % Args:
+        %   permutations(domainSize,\*): Permutations to look for
+        %
+        % Returns:
+        %   integer(1,\*): Indices of the given permutations, or ``0`` where not found
+            n = size(permutations, 2);
+            inds = zeros(1, n);
+            hash = self.hash;
+            hs = self.seed * permutations;
+            fast = exist('ismembc2') > 0;
+            if fast
+                % perform binary search; this function returns the last element which matches
+                lastInds = ismembc2(hs, hash);
+            end
+            for i = 1:n
+                h = hs(i);
+                if fast
+                    last = lastInds(i);
+                    if last == 0
+                        inds(i) = 0;
+                        continue
+                    end
+                    % then we need to find if other elements before match as well
+                    before = last - 1;
+                    while before > 0 && hash(before) == h
+                        before = before - 1;
+                    end
+                    f = before+1:last;
+                else
+                    f = find(hash == h);
+                    if isempty(f)
+                        inds(i) = 0;
+                        continue
+                    end
+                end
+                ind = self.perm(f);
+                if isempty(ind)
+                    inds(i) = 0;
+                else
+                    inds(i) = self.findElement(permutations(:,i), ind);
+                end
+            end
+        end
+
+        function inds = update(self, permutations)
+        % Returns the indices of the given permutations, adding them to the set if necessaryx
+        %
+        % Modifies the set in place.
+        %
+        % Args:
+        %   permutations(domainSize,\*): Permutations to look for
+        %
+        % Returns:
+        %   integer(1,\*): Indices of the given permutations
+            inds = self.find(permutations);
+            mask = (inds == 0);
+            inds1 = self.insert(permutations(:, find(mask)));
+            inds(mask) = inds1;
+        end
+
+    end
+
+end

--- a/tests/replab/perm/SetTest.m
+++ b/tests/replab/perm/SetTest.m
@@ -1,0 +1,16 @@
+function test_suite = SetTest()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+
+function test_sort
+    G = replab.DihedralGroup(10);
+    s = replab.perm.Set(G.domainSize);
+    s.insert(G.chain.allElements);
+    s.sort;
+    s.check
+end


### PR DESCRIPTION
We introduce a set of permutations backed by an ordered hash structure.

This lifts the work done in `FiniteGroupIndexedFamily` but provides additional methods.