### PR TITLE
Added `replab.Obj.laws` method that returns the relevant laws

### DIFF
--- a/src/+replab/Action.m
+++ b/src/+replab/Action.m
@@ -8,9 +8,19 @@ classdef Action < replab.Obj
         P % replab.Domain: Set acted upon
     end
 
-    methods
+    methods % Implementations
 
-        %% Abstract methods
+        % Obj
+
+        function l = laws(self)
+            l = replab.ActionLaws(self);
+        end
+
+    end
+
+    methods % Action methods
+
+        % Abstract method
 
         function p1 = leftAction(self, g, p)
         % Computes the left action of a group element on a set element
@@ -29,7 +39,7 @@ classdef Action < replab.Obj
             error('Abstract');
         end
 
-        %% Default implementations
+        % Default implementations
 
         function p1 = rightAction(self, p, g)
         % Computes the right action of a group element on a set element

--- a/src/+replab/Domain.m
+++ b/src/+replab/Domain.m
@@ -40,6 +40,16 @@ classdef Domain < replab.Obj
 
     end
 
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.DomainLaws(self);
+        end
+
+    end
+
     methods (Static) % Domain construction
 
         function domain = lambda(header, eqvFun, sampleFun)

--- a/src/+replab/FiniteFPGroup.m
+++ b/src/+replab/FiniteFPGroup.m
@@ -173,6 +173,12 @@ classdef FiniteFPGroup < replab.NiceFiniteGroup
             s = self.presentation;
         end
 
+        % Obj
+
+        function l = laws(self)
+            l = replab.FiniteFPGroupLaws(self);
+        end
+
         % Domain
 
         function res = eqv(self, x, y)

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -33,6 +33,12 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             end
         end
 
+        % Obj
+
+        function l = laws(self)
+            l = replab.FiniteGroupLaws(self);
+        end
+
     end
 
     methods % Group properties

--- a/src/+replab/FiniteIsomorphism.m
+++ b/src/+replab/FiniteIsomorphism.m
@@ -1,6 +1,16 @@
 classdef FiniteIsomorphism < replab.FiniteMorphism
 % Describes an isomorphism between finite groups
 
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.FiniteIsomorphismLaws(self);
+        end
+
+    end
+
     methods
 
         function K = computeKernel(self)

--- a/src/+replab/FiniteIsomorphismLaws.m
+++ b/src/+replab/FiniteIsomorphismLaws.m
@@ -16,7 +16,13 @@ classdef FiniteIsomorphismLaws < replab.FiniteMorphismLaws
 
     end
 
-    methods % Laws
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.FiniteIsomorphismLaws(self);
+        end
 
     end
 

--- a/src/+replab/FiniteMorphism.m
+++ b/src/+replab/FiniteMorphism.m
@@ -1,6 +1,16 @@
 classdef FiniteMorphism < replab.Morphism
 % Describes a morphism between finite groups
 
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.FiniteMorphismLaws(self);
+        end
+
+    end
+
     methods
 
         function K = kernel(self)

--- a/src/+replab/FreeGroup.m
+++ b/src/+replab/FreeGroup.m
@@ -72,6 +72,8 @@ classdef FreeGroup < replab.Group
             res = self.groupId ~= rhs.groupId;
         end
 
+        % Str
+
         function s = headerStr(self)
             s = ['Free group < ' strjoin(self.generatorNames, ', ') ' >'];
         end
@@ -83,13 +85,25 @@ classdef FreeGroup < replab.Group
             x = replab.FreeGroupWord.make(self, letters);
         end
 
+        % Obj
+
+        function l = laws(self)
+            l = replab.FreeGroupLaws(self);
+        end
+
+        % Domain
+
         function res = eqv(self, x, y)
             res = (x == y);
         end
 
+        % Monoid
+
         function z = compose(self, x, y)
             z = x*y;
         end
+
+        % Group
 
         function z = inverse(self, x)
             z = inv(x);

--- a/src/+replab/Group.m
+++ b/src/+replab/Group.m
@@ -3,7 +3,19 @@ classdef Group < replab.Monoid
 %
 % A group is a `.Monoid` where each element has an inverse.
 
-    methods % Abstract methods
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.GroupLaws(self);
+        end
+
+    end
+
+    methods % Group methods
+
+        % Abstract methods
 
         function xInv = inverse(self, x)
         % Computes the inverse of an element
@@ -20,9 +32,7 @@ classdef Group < replab.Monoid
             error('Abstract');
         end
 
-    end
-
-    methods % Methods with default implementations
+        % Methods with default implementations
 
         function x = leftConjugate(self, by, on)
         % Returns the left conjugate of a group element

--- a/src/+replab/HarmonizedIsotypic.m
+++ b/src/+replab/HarmonizedIsotypic.m
@@ -9,7 +9,17 @@ classdef HarmonizedIsotypic < replab.Isotypic
             self = self@replab.Isotypic(parent, irreps, E_internal);
         end
 
-        %% Rep methods
+    end
+
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.HarmonizedIsotypicLaws(self);
+        end
+
+        % Rep
 
         function rho = image_internal(self, g)
             p = self.parent.image_internal(g);
@@ -42,7 +52,7 @@ classdef HarmonizedIsotypic < replab.Isotypic
             end
         end
 
-        %% Isotypic methods
+        % Isotypic
 
         function [A Ainv] = changeOfBasis(self, i, j, context)
             A = eye(self.irrepDimension);

--- a/src/+replab/IndexedFamily.m
+++ b/src/+replab/IndexedFamily.m
@@ -61,28 +61,11 @@ classdef IndexedFamily < replab.Domain
             end
         end
 
-        function I = imap2(self, f, g)
-
-        end
-
-        function I = imap(self, isomorphism)
-        % Maps the elements of this indexed family through an isomorphism
-        %
-        % Assumes that the elements of this `.IndexedFamily` come from a finite group.
-        %
-        % Args:
-        %   isomorphism (`+replab.FiniteIsomorphism`): Isomorphism from the finite group in this IndexedFamily
-            I = replab.indf.MappedIndexedFamily(self, isomorphism);
-            atFun = @(ind) self.isomorphism.image(self.at(ind));
-            findFun = @(el) self.find(self.isomorphism.preimage(el));
-            I = replab.IndexedFamily.lambda(self.size, atFun, findFun);
-        end
-
     end
 
     methods % Implementations
 
-        % replab.Str
+        % Str
 
         function s = shortStr(self, maxColumns)
             s = sprintf('Indexed family of %s elements', replab.shortStr(self.size, maxColumns));
@@ -125,7 +108,13 @@ classdef IndexedFamily < replab.Domain
             lines = vertcat({self.shortStr(maxColumns)}, replab.str.align(table, 'rcl'));
         end
 
-        % replab.Domain
+        % Obj
+
+        function l = laws(self)
+            l = replab.IndexedFamilyLaws(self);
+        end
+
+        % Domain
 
         function res = eqv(self, x, y)
             indX = self.at(x);

--- a/src/+replab/Irreducible.m
+++ b/src/+replab/Irreducible.m
@@ -83,7 +83,11 @@ classdef Irreducible < replab.SubRep
             r = self.component(i).irrep(j);
         end
 
-        %% Str methods
+    end
+
+    methods % Implementations
+
+        % Str
 
         function names = hiddenFields(self)
             names = hiddenFields@replab.SubRep(self);
@@ -98,7 +102,13 @@ classdef Irreducible < replab.SubRep
             end
         end
 
-        %% Rep methods
+        % Obj
+
+        function l = laws(self)
+            l = replab.IrreducibleLaws(self);
+        end
+
+        % Rep
 
         function rho = image_internal(self, g)
             blocks = cellfun(@(iso) iso.image_internal(g), self.components, 'uniform', 0);
@@ -110,7 +120,7 @@ classdef Irreducible < replab.SubRep
             c = replab.IrreducibleCommutant(self);
         end
 
-        %% SubRep methods
+        % SubRep
 
         function irr = nice(self)
             components1 = cellfun(@(c) c.nice, self.components, 'uniform', 0);

--- a/src/+replab/Isotypic.m
+++ b/src/+replab/Isotypic.m
@@ -301,7 +301,11 @@ classdef Isotypic < replab.SubRep
             iso = replab.Isotypic(self.parent, irreps, E);
         end
 
-        %% Str methods
+    end
+
+    methods % Implementations
+
+        % Str
 
         function names = hiddenFields(self)
             names = hiddenFields@replab.SubRep(self);
@@ -351,7 +355,13 @@ classdef Isotypic < replab.SubRep
             end
         end
 
-        %% SubRep methods
+        % Obj
+
+        function l = laws(self)
+            l = replab.IsotypicLaws(self);
+        end
+
+        % SubRep
 
         function iso = refine(self)
             ctx = replab.Context.make;

--- a/src/+replab/LeftCosets.m
+++ b/src/+replab/LeftCosets.m
@@ -4,6 +4,16 @@ classdef LeftCosets < replab.CosetBase
 % Let $H$ be a subgroup of a group $G$. Then the left cosets are the sets $g H = \{ g h : h \in H \}$.
 % The set of such left cosets is often written $G / H = \{ g H : g \in G \}$.
 
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.LeftCosetsLaws(self);
+        end
+
+    end
+
     methods
 
         function self = LeftCosets(group, subgroup)

--- a/src/+replab/Monoid.m
+++ b/src/+replab/Monoid.m
@@ -23,7 +23,17 @@ classdef Monoid < replab.Domain
 
     end
 
-    methods % Default implementations
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.MonoidLaws(self);
+        end
+
+    end
+
+    methods % Monoid operations
 
         function z = composeAll(self, elements)
         % Composes a sequence of monoid elements

--- a/src/+replab/Obj.m
+++ b/src/+replab/Obj.m
@@ -6,7 +6,26 @@ classdef Obj < replab.Str
         id_ % (integer): Unique object ID
     end
 
-    methods
+    methods % Laws
+
+        function check(self)
+        % Checks the consistency of this object
+        %
+        % The default implementation checks the declared laws.
+            self.laws.check;
+        end
+
+        function l = laws(self)
+        % Returns the laws that this object obeys
+        %
+        % Returns:
+        %   `+replab.Laws`: The `.Laws` instance that is relevant for this object.
+            l = replab.Laws; % Empty instance by default
+        end
+
+    end
+
+    methods % Property cache
 
         function l = inCache(self, name)
         % Returns whether the value of the given property has already been computed
@@ -100,6 +119,10 @@ classdef Obj < replab.Str
                 self.cache_.(name) = res;
             end
         end
+
+    end
+
+    methods % Unique ID
 
         function i = id(self)
         % Returns the unique ID of this object (deprecated)

--- a/src/+replab/Partition.m
+++ b/src/+replab/Partition.m
@@ -22,7 +22,7 @@ classdef Partition < replab.Str
 
     methods
 
-        function check()
+        function check(self)
         % Verifies the sanity of this partition
             m = cellfun(@min, self.blocks); % blocks are ordered
             assert(all(m(2:end) - m(1:end-1)) > 0);

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -110,6 +110,12 @@ classdef PermutationGroup < replab.FiniteGroup
             end
         end
 
+        % replab.Obj
+
+        function l = laws(self)
+            l = replab.PermutationGroupLaws(self);
+        end
+
         % replab.Domain
 
         function b = eqv(self, x, y)

--- a/src/+replab/Rep.m
+++ b/src/+replab/Rep.m
@@ -37,7 +37,9 @@ classdef Rep < replab.Obj
         dimension % (integer): Representation dimension
     end
 
-    methods % Abstract methods
+    methods % Representation methods
+
+        % Abstract method
 
         function rho = image_internal(self, g)
         % Returns the image of a group element, dense or sparse
@@ -50,11 +52,7 @@ classdef Rep < replab.Obj
             error('Abstract');
         end
 
-    end
-
-    methods
-
-        %% Own methods
+        % Methods with default implementations
 
         function rho = image(self, g)
         % Returns the image of a group element
@@ -108,7 +106,7 @@ classdef Rep < replab.Obj
             end
         end
 
-        %% Properties
+        % Properties
 
         function b = overR(self)
         % Returns whether this representation is defined over the real field
@@ -263,6 +261,8 @@ classdef Rep < replab.Obj
 
     methods % Implementations
 
+        % Str
+
         function s = headerStr(self)
             p = {};
             if isequal(self.isUnitary, true)
@@ -335,6 +335,12 @@ classdef Rep < replab.Obj
             end
             p{1} = replab.str.capitalize(p{1});
             s = strjoin(p, ' ');
+        end
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.RepLaws(self);
         end
 
     end

--- a/src/+replab/RightCosets.m
+++ b/src/+replab/RightCosets.m
@@ -4,6 +4,16 @@ classdef RightCosets < replab.CosetBase
 % Let $H$ be a subgroup of a group $G$. Then the right cosets are the sets $H g = \{ h g : h \in H \}$.
 % The set of such right cosets is often written $H \\ G = \{ H g : g \in G \}$.
 
+    methods % Implementations
+
+        % Obj
+
+        function l = laws(self)
+            l = replab.RightCosetsLaws(self);
+        end
+
+    end
+
     methods
 
         function self = RightCosets(group, subgroup)

--- a/src/+replab/SignedPermutationGroup.m
+++ b/src/+replab/SignedPermutationGroup.m
@@ -38,6 +38,12 @@ classdef SignedPermutationGroup < replab.NiceFiniteGroup
 
     methods % Implementations
 
+        % Obj
+
+        function l = laws(self)
+            l = replab.SignedPermutationGroupLaws(self);
+        end
+
         % Domain
 
         function b = eqv(self, x, y)

--- a/src/+replab/SubRep.m
+++ b/src/+replab/SubRep.m
@@ -70,7 +70,11 @@ classdef SubRep < replab.Rep
             s = replab.nice.niceSubRep(self);
         end
 
-        %% Str methods
+    end
+
+    methods % Implementations
+
+        % Str
 
         function names = hiddenFields(self)
             names = replab.str.uniqueNames( ...
@@ -92,7 +96,13 @@ classdef SubRep < replab.Rep
             end
         end
 
-        %% Rep methods
+        % Obj
+
+        function l = laws(self)
+            l = replab.SubRepLaws(self);
+        end
+
+        % Rep
 
 % $$$         function [A Ainv] = unitaryChangeOfBasis(self)
 % $$$ TODO recover this


### PR DESCRIPTION
... and default implementations for all RepLAB objects with laws.

Fixes #305