### PR TITLE
Conjugacy classes have canonical representatives

### DIFF
--- a/src/+replab/+bsgs/ConjugacyClasses.m
+++ b/src/+replab/+bsgs/ConjugacyClasses.m
@@ -1,0 +1,80 @@
+classdef ConjugacyClasses
+% Computations involving conjugacy classes
+
+    methods (Static)
+
+        function [h1 g] = representative(group, h)
+        % Returns the lexicographically minimal representative of a conjugacy class
+        %
+        % We find the permutation ``g`` such that ``h1 = group.leftConjugate(g, h)`` is lex-minimal.
+        %
+        % For that, we first look for ``g = u1 g1`` with ``u1`` a transversal of the cosets
+        % for the first base point ``beta = 1`` of the stabilizer chain of ``group``.
+        %
+        % Now, we look at ``g`` such that ``gInv(h(g(beta)))`` is minimal. We minimize
+        % ``gInv1(uInv1(h(u1(g1(beta))))) = gInv1(uInv1(h(b)))`` by examining all
+        % possibilities for ``b``. We write ``a = uInv1(h(b))`` and examine the
+        % possibilities for ``gInv1(a)`` by considering the orbit of ``a`` in
+        % the stabilizer of ``group`` by ``beta``. We write ``gInv1 = ua g1a``
+        % where ``ua`` is a transversal of the cosets of this second stabilizer, and ``g1a``
+        % is an element of ``group`` that stabilizes both ``1`` and ``a``. This provides
+        % a candidate for ``g`` at the first level.
+        %
+        % At the first level, we collect all candidates ``h1 = gInv h g``, and work on the
+        % second base point ``beta = 2``, now with ``group`` stabilizing both ``beta_1 = 1`` and ``gInv(h(g(1)))``.
+        %
+        % Args:
+        %   group (`+replab.+bsgs.Permutatoin`): Group to explore
+        %   h (permutation): Group element
+        %
+        % Returns
+        % -------
+        % h1:
+        %   permutation: Lexicographically minimal element in the conjugacy class of ``h``
+        % g:
+        %   permutation: Permutation that left conjugates ``h`` to ``h1``
+            n = group.domainSize;
+            candidates = h; % candidates as rows
+            sub = group.lexChain;
+            beta = 1;
+            while beta <= n
+                candidates1 = zeros(0, n);
+                minImg = n + 1;
+                [stab1 orbit1 iOrbit1 U1 Uinv1] = sub.stabilizer(beta, true);
+                for j = 1:length(orbit1)
+                    b = orbit1(j);
+                    u1 = U1(:,j)';
+                    uinv1 = Uinv1(:,j)';
+                    for i = 1:size(candidates, 1)
+                        h = candidates(i,:);
+                        a = uinv1(h(b));
+                        if i == 1 || candidates(i,b) ~= candidates(i-1,b)
+                            [stab1a orbit1a iOrbit1a U1a Uinv1a] = stab1.stabilizer(a, true);
+                        end
+                        [m, ind] = min(orbit1a);
+                        if m < minImg
+                            candidates1 = zeros(0, n);
+                            minImg = m;
+                        end
+                        if m <= minImg
+                            u1a = U1a(:,ind)';
+                            uinv1a = Uinv1a(:,ind)';
+                            % ``rest u1a uinv1 h u1 uinv1a rest``
+                            h1 = u1a(uinv1(h(u1(uinv1a))));
+                            candidates1(end+1,:) = h1;
+                        end
+                    end
+                end
+                sub = stab1.stabilizer(minImg);
+                candidates = unique(candidates1, 'rows');
+                beta = beta + 1;
+            end
+            assert(size(candidates, 1) == 1);
+            h1 = candidates(1,:);
+            g = replab.bsgs.LeftConjugation(group, h, h1).find;
+            assert(all(group.leftConjugate(g, h) == h1));
+        end
+
+    end
+
+end

--- a/src/+replab/+bsgs/ConjugacyClasses.m
+++ b/src/+replab/+bsgs/ConjugacyClasses.m
@@ -35,10 +35,12 @@ classdef ConjugacyClasses
         %   permutation: Permutation that left conjugates ``h`` to ``h1``
             n = group.domainSize;
             candidates = h; % candidates as rows
+            conjugates = 1:n; % conjugating elements as rows
             sub = group.lexChain;
             beta = 1;
             while beta <= n
                 candidates1 = zeros(0, n);
+                conjugates1 = zeros(0, n);
                 minImg = n + 1;
                 stab2 = []; % corresponds to the result of sub.stabilizer(beta).stabilizer(minImg)
                 orbit2 = [];
@@ -51,34 +53,39 @@ classdef ConjugacyClasses
                     u1 = U1(:,j)';
                     uinv1 = Uinv1(:,j)';
                     for i = 1:size(candidates, 1)
-                        h = candidates(i,:);
-                        a = uinv1(h(b));
+                        c = candidates(i,:);
+                        ci = conjugates(i,:);
+                        cc = group.leftConjugate(ci, h);
+                        assert(all(c == cc));
+                        a = uinv1(c(b));
                         if i == 1 || candidates(i,b) ~= candidates(i-1,b)
                             orbit2 = stab1.orbitUnderG(1, a);
-                            %[stab1a orbit1a iOrbit1a U1a Uinv1a] = stab1.stabilizer(a, true);
                         end
                         m = min(orbit2);
                         if m <= minImg
                             if m < minImg
                                 minImg = m;
                                 candidates1 = zeros(0, n);
+                                conjugates1 = zeros(0, n);
                                 [stab2 orbit2 iOrbit2 U2 Uinv2] = stab1.stabilizer(minImg, true);
                             end
                             ind = iOrbit2(a);
                             u2 = U2(:,ind)';
                             uinv2 = Uinv2(:,ind)';
-                            h1 = uinv2(uinv1(h(u1(u2))));
-                            candidates1(end+1,:) = h1;
+                            c1 = uinv2(uinv1(c(u1(u2))));
+                            candidates1(end+1,:) = c1;
+                            conjugates1(end+1,:) = uinv2(uinv1(ci));
                         end
                     end
                 end
                 sub = stab2;
-                candidates = unique(candidates1, 'rows');
+                [candidates, I] = unique(candidates1, 'rows');
+                conjugates = conjugates1(I,:);
                 beta = beta + 1;
             end
             assert(size(candidates, 1) == 1);
             h1 = candidates(1,:);
-            g = replab.bsgs.LeftConjugation(group, h, h1).find;
+            g = conjugates1(1,:);
             assert(all(group.leftConjugate(g, h) == h1));
         end
 

--- a/src/+replab/+bsgs/ConjugacyClasses.m
+++ b/src/+replab/+bsgs/ConjugacyClasses.m
@@ -40,6 +40,11 @@ classdef ConjugacyClasses
             while beta <= n
                 candidates1 = zeros(0, n);
                 minImg = n + 1;
+                stab2 = []; % corresponds to the result of sub.stabilizer(beta).stabilizer(minImg)
+                orbit2 = [];
+                iOrbit2 = [];
+                U2 = [];
+                Uinv2 = [];
                 [stab1 orbit1 iOrbit1 U1 Uinv1] = sub.stabilizer(beta, true);
                 for j = 1:length(orbit1)
                     b = orbit1(j);
@@ -49,23 +54,25 @@ classdef ConjugacyClasses
                         h = candidates(i,:);
                         a = uinv1(h(b));
                         if i == 1 || candidates(i,b) ~= candidates(i-1,b)
-                            [stab1a orbit1a iOrbit1a U1a Uinv1a] = stab1.stabilizer(a, true);
+                            orbit2 = stab1.orbitUnderG(1, a);
+                            %[stab1a orbit1a iOrbit1a U1a Uinv1a] = stab1.stabilizer(a, true);
                         end
-                        [m, ind] = min(orbit1a);
-                        if m < minImg
-                            candidates1 = zeros(0, n);
-                            minImg = m;
-                        end
+                        m = min(orbit2);
                         if m <= minImg
-                            u1a = U1a(:,ind)';
-                            uinv1a = Uinv1a(:,ind)';
-                            % ``rest u1a uinv1 h u1 uinv1a rest``
-                            h1 = u1a(uinv1(h(u1(uinv1a))));
+                            if m < minImg
+                                minImg = m;
+                                candidates1 = zeros(0, n);
+                                [stab2 orbit2 iOrbit2 U2 Uinv2] = stab1.stabilizer(minImg, true);
+                            end
+                            ind = iOrbit2(a);
+                            u2 = U2(:,ind)';
+                            uinv2 = Uinv2(:,ind)';
+                            h1 = uinv2(uinv1(h(u1(u2))));
                             candidates1(end+1,:) = h1;
                         end
                     end
                 end
-                sub = stab1.stabilizer(minImg);
+                sub = stab2;
                 candidates = unique(candidates1, 'rows');
                 beta = beta + 1;
             end

--- a/src/+replab/+perm/conjugacyClassesByRandomSearch.m
+++ b/src/+replab/+perm/conjugacyClassesByRandomSearch.m
@@ -35,7 +35,7 @@ function classes = conjugacyClassesByRandomSearch(group)
                 end
             end
             if newClass
-                c = replab.ConjugacyClass(group, gn);
+                c = replab.ConjugacyClass.make(group, gn);
                 classes{1,end+1} = c;
                 remains = remains - c.size;
             end

--- a/src/+replab/CharacterTable.m
+++ b/src/+replab/CharacterTable.m
@@ -4,10 +4,10 @@ classdef CharacterTable < replab.Obj
 % Example:
 %   >>> s3ct = replab.CharacterTable.forPermutationGroup(replab.S(3));
 %   >>> disp(s3ct.table)
-%            [1, 3, 2]  [2, 3, 1]  [1, 2, 3]
+%            [1, 2, 3]  [1, 3, 2]  [2, 3, 1]
 %       X.1      1          1          1
-%       X.2      0         -1          2
-%       X.3     -1          1          1
+%       X.2      2          0         -1
+%       X.3      1         -1          1
 
     properties (SetAccess = protected)
         group % (`+replab.Group`): group represented by character table

--- a/src/+replab/ConjugacyClass.m
+++ b/src/+replab/ConjugacyClass.m
@@ -7,9 +7,6 @@ classdef ConjugacyClass < replab.FiniteSet
 %
 % Thus, the left cosets $G/C_{G}(r) = \{ g C_{G}(r) : g \in G \}$ are in one to one correspondence with
 % the elements of the conjugacy class.
-%
-% Contrary to the case of cosets, the `.representative` element is not chosen to be lexicographically
-% minimal.
 
     properties (SetAccess = protected)
         group % (`+replab.FiniteGroup`): Group containing this conjugacy class
@@ -18,14 +15,29 @@ classdef ConjugacyClass < replab.FiniteSet
 
     methods
 
-        function self = ConjugacyClass(group, arbitraryRepresentative, representativeCentralizer)
+        function self = ConjugacyClass(group, representative, representativeCentralizer)
             self.type = group.type;
             self.group = group;
-            self.representative = arbitraryRepresentative;
+            self.representative = representative;
             if nargin < 3 || isempty(representativeCentralizer)
-                representativeCentralizer = self.group.centralizer(arbitraryRepresentative);
+                representativeCentralizer = self.group.centralizer(representative);
             end
             self.representativeCentralizer = representativeCentralizer;
+        end
+
+    end
+
+    methods (Static)
+
+        function c = make(group, element, elementCentralizer)
+            if nargin < 3
+                elementCentralizer = group.centralizer(element);
+            end
+            prmGroup = group.niceMorphism.imageGroup(group); % TODO: image
+            prmElement = group.niceMorphism.imageElement(element);
+            [h1 g] = replab.bsgs.ConjugacyClasses.representative(prmGroup, prmElement);
+            representative = group.niceMorphism.preimageElement(h1);
+            c = replab.ConjugacyClass(group, representative);
         end
 
     end

--- a/src/+replab/ConjugacyClass.m
+++ b/src/+replab/ConjugacyClass.m
@@ -37,7 +37,8 @@ classdef ConjugacyClass < replab.FiniteSet
             prmElement = group.niceMorphism.imageElement(element);
             [h1 g] = replab.bsgs.ConjugacyClasses.representative(prmGroup, prmElement);
             representative = group.niceMorphism.preimageElement(h1);
-            c = replab.ConjugacyClass(group, representative);
+            representativeCentralizer = elementCentralizer.leftConjugateGroup(group.niceMorphism.preimageElement(g));
+            c = replab.ConjugacyClass(group, representative, representativeCentralizer);
         end
 
     end

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -1,7 +1,7 @@
 classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
 % Describes a group with a finite number of elements
 %
-% Each finite group has a type, that describes the most general group embedding its elements. 
+% Each finite group has a type, that describes the most general group embedding its elements.
 % For example, permutations of domain size ``n`` are embedded in the symmetric group of degree ``n``.
 
     properties (SetAccess = protected)
@@ -101,6 +101,17 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             for i = 2:length(eo)
                 e = lcm(e, eo(i));
             end
+        end
+
+        function c = conjugacyClass(self, g)
+        % Returns the conjugacy class corresponding to the given element
+        %
+        % Args:
+        %   g (element): Arbitrary group element
+        %
+        % Returns:
+        %   `.ConjugacyClass`: The conjugacy class containing the given element
+            c = replab.ConjugacyClass.make(self, g);
         end
 
         function c = conjugacyClasses(self)

--- a/src/+replab/FiniteSet.m
+++ b/src/+replab/FiniteSet.m
@@ -3,15 +3,13 @@ classdef FiniteSet < replab.Domain
 %
 % This is the base class for distinguished subsets of a `.FiniteGroup`, such as cosets or conjugacy classes.
 %
-% When non-empty, such sets have a distinguished `.representative` element. For some finite sets, this element
-% is used to quickly build the entire structure on demand.
-%
-% Cosets of permutation groups have stronger guarantees: their representative is chosen to be minimal under
-% the lexicographic order.
+% When non-empty, such sets have a distinguished `.representative` element, which is the element of the set
+% which is minimal under lexicographic ordering. For some finite sets, this element is used to explore the
+% entire structure on demand.
 
     properties (SetAccess = protected)
         type % (`.FiniteGroup`): Set of all elements of the same type as this set; satisfies ``type.type == type``
-        representative % (element of `.type`): Distinguished member of this set; if the set is empty, this value is arbitrary
+        representative % (element of `.type`): Minimal member of this set under lexicographic ordering. If the set is empty, value is undefined.
     end
 
     methods

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -191,11 +191,17 @@ classdef PermutationGroup < replab.FiniteGroup
                 classes = cell(1, n);
                 for i = 1:n
                     cl = sortrows(C{i}');
-                    classes{i} = replab.ConjugacyClass.make(self, cl(1,:));
+                    classes{i} = replab.ConjugacyClass(self, cl(1,:));
                 end
             else
                 classes = replab.perm.conjugacyClassesByRandomSearch(self);
             end
+            reps = zeros(length(classes), self.domainSize);
+            for i = 1:length(classes)
+                reps(i,:) = classes{i}.representative;
+            end
+            [~, I] = sortrows(reps);
+            classes = classes(I); % sort by minimal representative
         end
 
         function res = computeIsCyclic(self)

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -191,7 +191,7 @@ classdef PermutationGroup < replab.FiniteGroup
                 classes = cell(1, n);
                 for i = 1:n
                     cl = sortrows(C{i}');
-                    classes{i} = replab.ConjugacyClass(self, cl(1,:));
+                    classes{i} = replab.ConjugacyClass.make(self, cl(1,:));
                 end
             else
                 classes = replab.perm.conjugacyClassesByRandomSearch(self);

--- a/test_conjugacy.m
+++ b/test_conjugacy.m
@@ -1,9 +1,0 @@
-for i = 1:100
-    i
-    G = replab.S(10).randomProperSubgroup(3);
-    g1 = G.sample;
-    g2 = G.leftConjugate(G.sample, g1);
-    r1 = replab.bsgs.ConjugacyClasses.representative(G, g1);
-    r2 = replab.bsgs.ConjugacyClasses.representative(G, g2);
-    assert(all(r1 == r2));
-end

--- a/test_conjugacy.m
+++ b/test_conjugacy.m
@@ -1,0 +1,9 @@
+for i = 1:100
+    i
+    G = replab.S(10).randomProperSubgroup(3);
+    g1 = G.sample;
+    g2 = G.leftConjugate(G.sample, g1);
+    r1 = replab.bsgs.ConjugacyClasses.representative(G, g1);
+    r2 = replab.bsgs.ConjugacyClasses.representative(G, g2);
+    assert(all(r1 == r2));
+end

--- a/tests/replab/bsgs/ConjugacyClassesTest.m
+++ b/tests/replab/bsgs/ConjugacyClassesTest.m
@@ -1,0 +1,29 @@
+function test_suite = ConjugacyClassesTest()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+
+
+function test_conjugacyClassRepresentative
+    if ReplabTestParameters.onlyFastTests
+        n = 1;
+        d = 4;
+    else
+        n = 10;
+        d = 15;
+    end
+    S = replab.S(d);
+    for i = 1:n
+        G = S.randomProperSubgroup(3);
+        g1 = G.sample;
+        s = G.sample;
+        g2 = G.leftConjugate(s, g1);
+        r1 = G.conjugacyClass(g1).representative;
+        r2 = G.conjugacyClass(g2).representative;
+        assertEqual(r1, r2);
+    end
+end


### PR DESCRIPTION
We construct conjugacy classes by looking for their minimal representative under lexicographic ordering.