### PR TITLE
Support for method groups

### DIFF
--- a/src/+replab/+compat/uniqueStable.m
+++ b/src/+replab/+compat/uniqueStable.m
@@ -1,0 +1,4 @@
+function res = uniqueStable(values)
+    [~,ind,~] = unique(values, 'first');
+    res = values(sort(ind));
+end

--- a/src/+replab/+directproduct/OfFiniteGroups.m
+++ b/src/+replab/+directproduct/OfFiniteGroups.m
@@ -33,6 +33,51 @@ classdef OfFiniteGroups < replab.NiceFiniteGroup & replab.directproduct.OfCompac
             ind = ind + 1;
         end
 
+        function o = computeOrder(self)
+            o = vpi(1);
+            % The order of a direct product is the product of the
+            % order of the factors
+            for i = 1:self.nFactors
+                o = o * self.factor(i).order;
+            end
+        end
+
+        function e = computeElements(self)
+            e = replab.IndexedFamily.lambda(self.order, ...
+                                            @(ind) self.atFun(ind), ...
+                                            @(g) self.findFun(g));
+            % The elements of a direct product of finite groups can be
+            % enumerated by considering the direct product as a cartesian
+            % product of sets, and decomposing the index a la ind2sub/sub2ind
+            % which is the role of the `atFun` and `findFun` functions
+
+            % TODO: verify ordering
+        end
+
+        function gd = computeDecomposition(self)
+            T = {};
+            % The decomposition of a direct product into sets
+            % is simply the concatenation of the sequence of sets
+            % corresponding to each factor
+            for i = 1:self.nFactors
+                D = self.factor(i).decomposition.T;
+                Ti = cell(1, length(D));
+                for j = 1:length(D)
+                    Dj = D{j};
+                    Tij = cell(1, length(Dj));
+                    for k = 1:length(Dj)
+                       Djk = Dj{k};
+                       Tijk = self.identity;
+                       Tijk{i} = Djk;
+                       Tij{k} = Tijk;
+                    end
+                    Ti{j} = Tij;
+                end
+                T = horzcat(T, Ti);
+            end
+            gd = replab.FiniteGroupDecomposition(self, T);
+        end
+
     end
 
     methods
@@ -122,53 +167,6 @@ classdef OfFiniteGroups < replab.NiceFiniteGroup & replab.directproduct.OfCompac
                     return
                 end
             end
-        end
-
-        % FiniteGroup
-
-        function o = computeOrder(self)
-            o = vpi(1);
-            % The order of a direct product is the product of the
-            % order of the factors
-            for i = 1:self.nFactors
-                o = o * self.factor(i).order;
-            end
-        end
-
-        function e = computeElements(self)
-            e = replab.IndexedFamily.lambda(self.order, ...
-                                            @(ind) self.atFun(ind), ...
-                                            @(g) self.findFun(g));
-            % The elements of a direct product of finite groups can be
-            % enumerated by considering the direct product as a cartesian
-            % product of sets, and decomposing the index a la ind2sub/sub2ind
-            % which is the role of the `atFun` and `findFun` functions
-
-            % TODO: verify ordering
-        end
-
-        function gd = computeDecomposition(self)
-            T = {};
-            % The decomposition of a direct product into sets
-            % is simply the concatenation of the sequence of sets
-            % corresponding to each factor
-            for i = 1:self.nFactors
-                D = self.factor(i).decomposition.T;
-                Ti = cell(1, length(D));
-                for j = 1:length(D)
-                    Dj = D{j};
-                    Tij = cell(1, length(Dj));
-                    for k = 1:length(Dj)
-                       Djk = Dj{k};
-                       Tijk = self.identity;
-                       Tijk{i} = Djk;
-                       Tij{k} = Tijk;
-                    end
-                    Ti{j} = Tij;
-                end
-                T = horzcat(T, Ti);
-            end
-            gd = replab.FiniteGroupDecomposition(self, T);
         end
 
         % NiceFiniteGroup

--- a/src/+replab/+infra/+repl/formatHelp.m
+++ b/src/+replab/+infra/+repl/formatHelp.m
@@ -114,5 +114,5 @@ function res = formatHelp(txt, context, helpCommand, strongIds, plainIds)
         lines = {lines{1:tableLN(1)-1} tableLines{:} lines{tableLN(end)+1:end}};
     end
 
-    res = strjoin(lines, '\n');
+    res = strjoin(cellfun(@deblank, lines, 'uniform', 0), '\n');
 end

--- a/src/+replab/+infra/+repl/help_full_class.liquid
+++ b/src/+replab/+infra/+repl/help_full_class.liquid
@@ -42,8 +42,8 @@
 \t\n
 {% end %}
 
-{% if ~isempty(el.allMethods) %}
 {% for mg in el.allMethodGroups %}
+{% if mg.hasAccessibleMethods %}
    Methods:\t{{ mg.name }}\n
    \t\n
 {% for m in mg.methodsInGroup %}

--- a/src/+replab/+infra/+repl/help_full_class.liquid
+++ b/src/+replab/+infra/+repl/help_full_class.liquid
@@ -43,15 +43,15 @@
 {% end %}
 
 {% if ~isempty(el.allMethods) %}
-{% if length(el.allMethods) == 1 %}
-   Method:\t\n
-{% else %}
-   Methods:\t\n
-{% end %}
-{% for m in el.allMethods %}
+{% for mg in el.allMethodGroups %}
+   Methods:\t{{ mg.name }}\n
+   \t\n
+{% for m in mg.methodsInGroup %}
 {% if m.isAccessible %}
      `~{{m.fullIdentifier}}` \t{{m.declarations.bestEffortDocFirstLine}}\n
 {% end %}
+{% end %}
+\t\n
 {% end %}
 {% end %}
 \n

--- a/src/+replab/+infra/+sphinx/class.liquid
+++ b/src/+replab/+infra/+sphinx/class.liquid
@@ -7,9 +7,9 @@
 %    - `~{{ el.matlabDomainIdentifier }}` -- {{ el.declarations.bestEffortDocFirstLine }}\n
 {% end %}
 {% end %}
-
+%\n
 {% for mg in cl.allMethodGroups %}
-% Methods: {{ mg.name }}\n
+%    Methods: {{ mg.name }}\n
 %\n
 {% for m in mg.methodsInGroup %}
 {% if m.isAccessible %}

--- a/src/+replab/+infra/+sphinx/class.liquid
+++ b/src/+replab/+infra/+sphinx/class.liquid
@@ -10,13 +10,13 @@
 
 {% for mg in cl.allMethodGroups %}
 % Methods: {{ mg.name }}\n
-\n
+%\n
 {% for m in mg.methodsInGroup %}
 {% if m.isAccessible %}
 %    - `~{{ m.matlabDomainIdentifier }}` -- {{ m.declarations.bestEffortDocFirstLine }}\n
 {% end %}
 {% end %}
-\n
+%\n
 {% end %}
 
 {% if ~isempty(cl.inheritedDocumentationElements) %}

--- a/src/+replab/+infra/+sphinx/class.liquid
+++ b/src/+replab/+infra/+sphinx/class.liquid
@@ -2,14 +2,20 @@
 % .. admonition:: Class members list\n
 %    :class: collapsed\n
 %\n
+{% if ~isempty(cl.allProperties) %}
+%    **Properties**\n
+%\n
 {% for el in cl.allProperties %}
 {% if el.isAccessible %}
 %    - `~{{ el.matlabDomainIdentifier }}` -- {{ el.declarations.bestEffortDocFirstLine }}\n
 {% end %}
 {% end %}
 %\n
+{% end %}
+
 {% for mg in cl.allMethodGroups %}
-%    Methods: {{ mg.name }}\n
+{% if mg.hasAccessibleMethods %}
+%    **{{ mg.name }}**\n
 %\n
 {% for m in mg.methodsInGroup %}
 {% if m.isAccessible %}
@@ -17,6 +23,7 @@
 {% end %}
 {% end %}
 %\n
+{% end %}
 {% end %}
 
 {% if ~isempty(cl.inheritedDocumentationElements) %}

--- a/src/+replab/+infra/+sphinx/class.liquid
+++ b/src/+replab/+infra/+sphinx/class.liquid
@@ -2,12 +2,22 @@
 % .. admonition:: Class members list\n
 %    :class: collapsed\n
 %\n
-{% for el in cl.allElements %}
+{% for el in cl.allProperties %}
 {% if el.isAccessible %}
 %    - `~{{ el.matlabDomainIdentifier }}` -- {{ el.declarations.bestEffortDocFirstLine }}\n
 {% end %}
 {% end %}
-%\n
+
+{% for mg in cl.allMethodGroups %}
+% Methods: {{ mg.name }}\n
+\n
+{% for m in mg.methodsInGroup %}
+{% if m.isAccessible %}
+%    - `~{{ m.matlabDomainIdentifier }}` -- {{ m.declarations.bestEffortDocFirstLine }}\n
+{% end %}
+{% end %}
+\n
+{% end %}
 
 {% if ~isempty(cl.inheritedDocumentationElements) %}
 % .. admonition:: Inherited elements\n

--- a/src/+replab/+infra/Class.m
+++ b/src/+replab/+infra/Class.m
@@ -92,7 +92,7 @@ classdef Class < replab.infra.SourceElement
             am = am(:).';
             am = am(cellfun(@(x) x.isMethod, am));
             group = cellfun(@(x) x.declarations.bestEffortGroup, am, 'uniform', 0);
-            groups = unique(group, 'stable');
+            groups = replab.compat.uniqueStable(group);
             amg = cell(1, length(groups));
             for i = 1:length(groups)
                 name = groups{i};

--- a/src/+replab/+infra/Class.m
+++ b/src/+replab/+infra/Class.m
@@ -92,7 +92,7 @@ classdef Class < replab.infra.SourceElement
             am = am(:).';
             am = am(cellfun(@(x) x.isMethod, am));
             group = cellfun(@(x) x.declarations.bestEffortGroup, am, 'uniform', 0);
-            groups = replab.compat.uniqueStable(group);
+            groups = self.allMethodGroupNames;
             amg = cell(1, length(groups));
             for i = 1:length(groups)
                 name = groups{i};
@@ -120,6 +120,10 @@ classdef Class < replab.infra.SourceElement
         % Returns a row cell vector containing all properties, inc. inherited, sorted by name
             ae = self.allElements;
             ap = ae(cellfun(@(x) x.isProperty, ae));
+        end
+
+        function an = allMethodGroupNames(self)
+            an = replab.compat.uniqueStable(horzcat(self.inheritedMethodGroupNames, self.ownMethodGroupNames));
         end
 
         function oe = ownDocumentationElements(self)
@@ -169,6 +173,20 @@ classdef Class < replab.infra.SourceElement
             om = oe(cellfun(@(x) x.isMethod, oe));
         end
 
+        function on = ownMethodGroupNames(self)
+            om = self.ownMethods;
+            n = length(om);
+            on = cell(1, n);
+            for i = 1:n
+                m = om{i};
+                if isfield(m.attributes, 'group')
+                    on{i} = m.attributes.group;
+                else
+                    on{i} = '';
+                end
+            end
+        end
+
         function op = ownProperties(self)
             oe = self.ownElements;
             op = oe(cellfun(@(x) x.isProperty, oe));
@@ -200,6 +218,15 @@ classdef Class < replab.infra.SourceElement
                 self.inheritedElementsStruct_ = ie;
             end
             ie = self.inheritedElementsStruct_;
+        end
+
+        function in = inheritedMethodGroupNames(self)
+            asc = fliplr(self.allSuperclasses); % visit in reverse order
+            in = cell(1, 0);
+            for i = 1:length(asc)
+                in = horzcat(in, asc{i}.ownMethodGroupNames);
+            end
+            in = replab.compat.uniqueStable(in);
         end
 
         function ie = inheritedElements(self)
@@ -255,16 +282,21 @@ classdef Class < replab.infra.SourceElement
 
         function asc = computeAllSuperclasses(self)
             asc = {};
+            ids = {};
             visitedClassIds = struct;
             queue = self.ownSuperclasses;
             while ~isempty(queue)
                 c = queue{1};
                 queue = queue(2:end);
-                id = c.shmIdentifier;
-                if ~isfield(visitedClassIds, id)
-                    visitedClassIds.(id) = true;
+                [~, ind] = ismember(c.fullIdentifier, ids);
+                if ind == 0
+                    ids{1,end+1} = c.fullIdentifier;
                     asc{1,end+1} = c;
                     queue = horzcat(queue, c.ownSuperclasses);
+                else
+                    rest = setdiff(1:length(ids), ind);
+                    ids = horzcat(ids(rest), {c.fullIdentifier});
+                    asc = horzcat(asc(rest), {c});
                 end
             end
         end

--- a/src/+replab/+infra/ClassData.m
+++ b/src/+replab/+infra/ClassData.m
@@ -63,8 +63,12 @@ classdef ClassData < replab.Str
                 return
             end
             % Remove an eventual comment
-            parts = strsplit(line, '%');
-            line = strtrim(parts{1});
+            ind = find([line '%'] == '%', 1);
+            group = strtrim(strrep(line(ind+1:end), '(Abstract)', ''));
+            if isequal(group, 'Implementations')
+                group = '';
+            end
+            line = strtrim(line(1:ind-1));
             if isequal(line, 'methods')
                 % No attributes
                 attributes = struct;
@@ -75,6 +79,9 @@ classdef ClassData < replab.Str
                     replab.infra.parseError(ct, pos, 'Was expecting attributes, but unknown format encountered');
                 end
                 attributes = replab.infra.parseAttributes(tokens{1});
+            end
+            if ~isempty(group)
+                attributes.group = group;
             end
             while 1
                 [res met] = replab.infra.ClassData.parseMethodsElement(ct, pos, attributes);

--- a/src/+replab/+infra/ClassData.m
+++ b/src/+replab/+infra/ClassData.m
@@ -65,7 +65,7 @@ classdef ClassData < replab.Str
             % Remove an eventual comment
             ind = find([line '%'] == '%', 1);
             group = strtrim(strrep(line(ind+1:end), '(Abstract)', ''));
-            if isequal(group, 'Implementations')
+            if isequal(group, 'Implementations') || isequal(group, 'Implementation')
                 group = '';
             end
             line = strtrim(line(1:ind-1));

--- a/src/+replab/+infra/Declarations.m
+++ b/src/+replab/+infra/Declarations.m
@@ -47,6 +47,20 @@ classdef Declarations < replab.Str
             els = els(mask);
         end
 
+        function g = bestEffortGroup(self)
+            els = self.findAll;
+            mask = cellfun(@(e) isfield(e.attributes, 'group'), els);
+            groups = unique(cellfun(@(e) e.attributes.group, els(mask), 'uniform', 0));
+            if length(groups) > 1
+                warning('Element %s belongs to more than one group: %s', self.classElement.fullIdentifier, strjoin(groups, ' & '));
+            end
+            if isempty(groups)
+                g = 'General';
+            else
+                g = groups{1};
+            end
+        end
+
         function l = bestEffortHasPropertyType(self)
             el = self.findBestDocumented;
             l = el.doc.hasPropertyType;

--- a/src/+replab/+infra/MethodGroup.m
+++ b/src/+replab/+infra/MethodGroup.m
@@ -1,0 +1,19 @@
+classdef MethodGroup < replab.Str
+% A group of methods in a class
+
+    properties
+        name % (charstring): Name of the group
+        methodsInGroup % (cell(1,\*) of `.ClassElement`): Methods in the group
+    end
+
+    methods
+
+        function self = MethodGroup(name, methodsInGroup)
+            self.name = name;
+            self.methodsInGroup = methodsInGroup;
+        end
+
+    end
+
+
+end

--- a/src/+replab/+infra/MethodGroup.m
+++ b/src/+replab/+infra/MethodGroup.m
@@ -13,6 +13,10 @@ classdef MethodGroup < replab.Str
             self.methodsInGroup = methodsInGroup;
         end
 
+        function l = hasAccessibleMethods(self)
+            l = any(cellfun(@(m) m.isAccessible, self.methodsInGroup));
+        end
+
     end
 
 

--- a/src/+replab/+semidirectproduct/OfFiniteGroups.m
+++ b/src/+replab/+semidirectproduct/OfFiniteGroups.m
@@ -24,6 +24,32 @@ classdef OfFiniteGroups < replab.semidirectproduct.OfCompactGroups & replab.Nice
 
     end
 
+    methods (Access = protected)
+
+        % FiniteGroup
+
+        function o = computeOrder(self)
+            o = self.H.order * self.N.order;
+        end
+
+        function e = computeElements(self)
+            e = replab.IndexedFamily.lambda(self.order, ...
+                                            @(ind) self.atFun(ind), ...
+                                            @(g) self.findFun(g));
+        end
+
+        function gd = computeDecomposition(self)
+            TH = self.H.decomposition.T;
+            TN = self.N.decomposition.T;
+            idN = self.N.identity;
+            idH = self.H.identity;
+            TH1 = cellfun(@(t) cellfun(@(h) {h idN}, t, 'uniform', 0), TH, 'uniform', 0);
+            TN1 = cellfun(@(t) cellfun(@(n) {idH n}, t, 'uniform', 0), TN, 'uniform', 0);
+            gd = replab.FiniteGroupDecomposition(self, horzcat(TH1, TN1));
+        end
+
+    end
+
     methods % Implementations
 
         % Domain
@@ -46,28 +72,6 @@ classdef OfFiniteGroups < replab.semidirectproduct.OfCompactGroups & replab.Nice
 
         function xInv = inverse(self, x)
             xInv = inverse@replab.semidirectproduct.OfCompactGroups(self, x);
-        end
-
-        % FiniteGroup
-
-        function o = computeOrder(self)
-            o = self.H.order * self.N.order;
-        end
-
-        function e = computeElements(self)
-            e = replab.IndexedFamily.lambda(self.order, ...
-                                            @(ind) self.atFun(ind), ...
-                                            @(g) self.findFun(g));
-        end
-
-        function gd = computeDecomposition(self)
-            TH = self.H.decomposition.T;
-            TN = self.N.decomposition.T;
-            idN = self.N.identity;
-            idH = self.H.identity;
-            TH1 = cellfun(@(t) cellfun(@(h) {h idN}, t, 'uniform', 0), TH, 'uniform', 0);
-            TN1 = cellfun(@(t) cellfun(@(n) {idH n}, t, 'uniform', 0), TN, 'uniform', 0);
-            gd = replab.FiniteGroupDecomposition(self, horzcat(TH1, TN1));
         end
 
     end

--- a/src/+replab/AbstractGroup.m
+++ b/src/+replab/AbstractGroup.m
@@ -83,6 +83,22 @@ classdef AbstractGroup < replab.NiceFiniteGroup
 
     end
 
+    methods (Access = protected)
+
+        function r = computeRelators(self)
+            r = replab.fp.relatorsForPermutationGroup(self.permutationGroup, self.names);
+        end
+
+        function m = computeNiceMorphism(self)
+            if self.order <= 65536
+                m = replab.nfg.AbstractGroupIsomorphismEnumeration.make(self);
+            else
+                m = replab.nfg.AbstractGroupIsomorphismChain(self);
+            end
+        end
+
+    end
+
     methods
 
         function self = AbstractGroup(names, permutationGroup, relators)
@@ -109,10 +125,6 @@ classdef AbstractGroup < replab.NiceFiniteGroup
         % Returns:
         %   cell(1,\*) of charstring: Words defining the relators
             r = self.cached('relators', @() self.computeRelators);
-        end
-
-        function r = computeRelators(self)
-            r = replab.fp.relatorsForPermutationGroup(self.permutationGroup, self.names);
         end
 
         function letters = toLetters(self, word)
@@ -252,14 +264,6 @@ classdef AbstractGroup < replab.NiceFiniteGroup
                 else
                     perm = pg.composeWithInverse(perm, pg.generator(-l));
                 end
-            end
-        end
-
-        function m = computeNiceMorphism(self)
-            if self.order <= 65536
-                m = replab.nfg.AbstractGroupIsomorphismEnumeration.make(self);
-            else
-                m = replab.nfg.AbstractGroupIsomorphismChain(self);
             end
         end
 

--- a/src/+replab/ConjugacyClass.m
+++ b/src/+replab/ConjugacyClass.m
@@ -43,6 +43,15 @@ classdef ConjugacyClass < replab.FiniteSet
 
     end
 
+    methods (Access = protected)
+
+        function E = computeElements(self)
+            T = self.group.leftCosetsOf(self.representativeCentralizer).transversal;
+            E = cellfun(@(t) self.group.leftConjugate(t, self.representative), T, 'uniform', 0);
+        end
+
+    end
+
     methods % Implementations
 
         % Domain
@@ -71,11 +80,6 @@ classdef ConjugacyClass < replab.FiniteSet
             % We want to solve ``t == b s b^-1`` with ``s`` the representative
             B = self.group.findLeftConjugations(s, t, sCentralizer);
             b = ~isempty(B);
-        end
-
-        function E = computeElements(self)
-            T = self.group.leftCosetsOf(self.representativeCentralizer).transversal;
-            E = cellfun(@(t) self.group.leftConjugate(t, self.representative), T, 'uniform', 0);
         end
 
     end

--- a/src/+replab/Domain.m
+++ b/src/+replab/Domain.m
@@ -12,7 +12,7 @@ classdef Domain < replab.Obj
 
 % Those elements can be compared (`~replab.Domain.eqv`), and random elements can be produced (`~replab.Domain.sample`).
 
-    methods % Abstract
+    methods % Sampling and equality test
 
         function t = sample(self)
         % Samples an element from this set

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -42,6 +42,62 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
 
     end
 
+    methods (Access = protected)
+
+        function o = computeOrder(self)
+        % See `.order`
+            error('Abstract');
+        end
+
+        function m = computeNiceMorphism(self)
+        % See `.niceMorphism`
+            error('Abstract');
+        end
+
+        function D = computeDecomposition(self)
+        % See `.decomposition`
+            error('Abstract');
+        end
+
+        function e = computeExponent(self)
+            eo = cellfun(@(c) self.elementOrder(c.representative), self.conjugacyClasses);
+            eo = unique(eo);
+            e = eo(1);
+            for i = 2:length(eo)
+                e = lcm(e, eo(i));
+            end
+        end
+
+        function c = computeConjugacyClasses(self)
+            error('Abstract');
+        end
+
+        function R = computeRecognize(self)
+            A = replab.atlas.Standard;
+            R = A.recognize(self);
+        end
+
+
+        function res = computeIsCyclic(self)
+            error('Abstract');
+        end
+
+        function res = computeIsSimple(self)
+            error('Abstract');
+        end
+
+        function sub = computeDerivedSubgroup(self)
+        % See `.derivedSubgroup`
+            error('Abstract');
+        end
+
+        function m = computeDefaultAbstractGroupIsomorphism(self)
+            names = arrayfun(@(i) ['x' num2str(i)], 1:self.nGenerators, 'uniform', 0);
+            m = self.abstractGroupIsomorphism(names);
+        end
+
+    end
+
     methods % Group properties
 
         function s = size(self)
@@ -56,20 +112,11 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             o = self.cached('order', @() self.computeOrder);
         end
 
-        function o = computeOrder(self)
-        % See `.order`
-            error('Abstract');
-        end
-
         function f = niceMorphism(self)
         % Returns the isomorphism from this group to a permutation group
             f = self.cached('niceMorphism', @() self.computeNiceMorphism);
         end
 
-        function m = computeNiceMorphism(self)
-        % See `.niceMorphism`
-            error('Abstract');
-        end
 
         function D = decomposition(self)
         % Returns a decomposition of this group as a product of sets
@@ -77,11 +124,6 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         % Returns:
         %   `.FiniteGroupDecomposition`: The group decomposition
             D = self.cached('decomposition', @() self.computeDecomposition);
-        end
-
-        function D = computeDecomposition(self)
-        % See `.decomposition`
-            error('Abstract');
         end
 
         function e = exponent(self)
@@ -94,14 +136,6 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             e = self.cached('exponent', @() self.computeExponent);
         end
 
-        function e = computeExponent(self)
-            eo = cellfun(@(c) self.elementOrder(c.representative), self.conjugacyClasses);
-            eo = unique(eo);
-            e = eo(1);
-            for i = 2:length(eo)
-                e = lcm(e, eo(i));
-            end
-        end
 
         function c = conjugacyClass(self, g)
         % Returns the conjugacy class corresponding to the given element
@@ -122,21 +156,12 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             c = self.cached('conjugacyClasses', @() self.computeConjugacyClasses);
         end
 
-        function c = computeConjugacyClasses(self)
-            error('Abstract');
-        end
-
         function R = recognize(self)
         % Attempts to recognize this group in the standard atlas
         %
         % Returns:
         %   `+replab.AtlasResult` or []: A result in case the group is identified; or ``[]`` if unrecognized.
             R = self.cached('recognize', @() self.computeRecognize);
-        end
-
-        function R = computeRecognize(self)
-            A = replab.atlas.Standard;
-            R = A.recognize(self);
         end
 
         function b = isTrivial(self)
@@ -168,17 +193,9 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             res = self.cached('isCyclic', @() self.computeIsCyclic);
         end
 
-        function res = computeIsCyclic(self)
-            error('Abstract');
-        end
-
         function res = isSimple(self)
         % Returns whether this group is simple
             res = self.cached('isSimple', @() self.computeIsSimple);
-        end
-
-        function res = computeIsSimple(self)
-            error('Abstract');
         end
 
     end
@@ -405,11 +422,6 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         % Returns:
         %   `+replab.FiniteGroup`: The derived subgroup
             sub = self.cached('derivedSubgroup', @() self.computeDerivedSubgroup);
-        end
-
-        function sub = computeDerivedSubgroup(self)
-        % See `.derivedSubgroup`
-            error('Abstract');
         end
 
         function sub = center(self)
@@ -722,12 +734,6 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         %   `.FiniteIsomorphism`: Isomorphism to an abstract group with generators named ``x1``, ``x2`` etc.
             m = self.cached('defaultAbstractGroupIsomorphism', @() self.computeDefaultAbstractGroupIsomorphism);
         end
-
-        function m = computeDefaultAbstractGroupIsomorphism(self)
-            names = arrayfun(@(i) ['x' num2str(i)], 1:self.nGenerators, 'uniform', 0);
-            m = self.abstractGroupIsomorphism(names);
-        end
-
 
         function m = abstractGroupIsomorphism(self, names)
         % Returns an isomorphism to an abstract group

--- a/src/+replab/FiniteSet.m
+++ b/src/+replab/FiniteSet.m
@@ -12,6 +12,15 @@ classdef FiniteSet < replab.Domain
         representative % (element of `.type`): Minimal member of this set under lexicographic ordering. If the set is empty, value is undefined.
     end
 
+    methods (Access = protected)
+
+        function E = computeElements(self)
+        % See `.elements`
+            error('Abstract');
+        end
+
+    end
+
     methods
 
         function s = size(self)
@@ -41,11 +50,6 @@ classdef FiniteSet < replab.Domain
         % Returns:
         %   `.IndexedFamily`: An enumeration of the set elements
             E = self.cached('elements', @() self.computeElements);
-        end
-
-        function E = computeElements(self)
-        % See `.elements`
-            error('Abstract');
         end
 
     end

--- a/src/+replab/LeftCoset.m
+++ b/src/+replab/LeftCoset.m
@@ -36,6 +36,24 @@ classdef LeftCoset < replab.Coset
 
     end
 
+    methods (Access = protected)
+
+        function E = computeElements(self)
+        % Returns an indexed family of the elements of this coset
+        %
+        % Returns:
+        %   `+replab.IndexedFamily`: Elements
+            H = self.groupChain.allElements;
+            g = self.representative;
+            if ~isempty(self.isomorphism)
+                g = self.isomorphism.imageElement(g);
+            end
+            matrix = sortrows(g(H'))';
+            E = replab.indf.FiniteGroupIndexedFamily(matrix, self.isomorphism);
+        end
+
+    end
+
     methods % Implementations
 
         % Domain
@@ -67,20 +85,6 @@ classdef LeftCoset < replab.Coset
             end
             el = replab.bsgs.Cosets.leftRepresentative(self.groupChain, el);
             b = isequal(self.representative, el);
-        end
-
-        function E = computeElements(self)
-        % Returns an indexed family of the elements of this coset
-        %
-        % Returns:
-        %   `+replab.IndexedFamily`: Elements
-            H = self.groupChain.allElements;
-            g = self.representative;
-            if ~isempty(self.isomorphism)
-                g = self.isomorphism.imageElement(g);
-            end
-            matrix = sortrows(g(H'))';
-            E = replab.indf.FiniteGroupIndexedFamily(matrix, self.isomorphism);
         end
 
     end

--- a/src/+replab/Monoid.m
+++ b/src/+replab/Monoid.m
@@ -7,7 +7,7 @@ classdef Monoid < replab.Domain
         identity % (element): Monoid identity element
     end
 
-    methods % Abstract methods
+    methods % Monoid operations (Abstract)
 
         function z = compose(self, x, y)
         % Composes two monoid/group elements

--- a/src/+replab/NiceFiniteGroup.m
+++ b/src/+replab/NiceFiniteGroup.m
@@ -44,34 +44,15 @@ classdef NiceFiniteGroup < replab.FiniteGroup
             G = self.cached('niceGroup', @() self.computeNiceGroup);
         end
 
+    end
+
+    methods (Access = protected)
+
         function G = computeNiceGroup(self)
             gens = cellfun(@(g) self.niceImage(g), self.generators, 'uniform', 0);
             ds = length(self.niceImage(self.identity));
             G = replab.PermutationGroup(ds, gens, self.cachedOrEmpty('order'));
         end
-
-    end
-
-    methods % Implementation
-
-        % Domain
-
-        function g = sample(self)
-            g = self.niceMorphism.preimageElement(self.niceGroup.sample);
-            % TODO: optimize
-        end
-
-        % FiniteSet
-
-        function E = computeElements(self)
-            atFun = @(ind) self.niceMorphism.preimageElement(self.niceGroup.elements.at(ind));
-            findFun = @(el) self.niceGroup.elements.find(self.niceImage(el));
-            E = replab.IndexedFamily.lambda(self.order, atFun, findFun);
-        end
-
-        % FiniteGroup
-
-        % Group properties
 
         function order = computeOrder(self)
             order = self.niceGroup.order;
@@ -96,6 +77,35 @@ classdef NiceFiniteGroup < replab.FiniteGroup
         function res = computeIsCyclic(self)
             res = self.niceGroup.isCyclic;
         end
+
+        function res = computeIsSimple(self)
+            res = self.niceGroup.isSimple;
+        end
+
+        function E = computeElements(self)
+            atFun = @(ind) self.niceMorphism.preimageElement(self.niceGroup.elements.at(ind));
+            findFun = @(el) self.niceGroup.elements.find(self.niceImage(el));
+            E = replab.IndexedFamily.lambda(self.order, atFun, findFun);
+        end
+
+        function sub = computeDerivedSubgroup(self)
+            sub = self.niceMorphism.preimageGroup(self.niceGroup.derivedSubgroup);
+        end
+
+    end
+
+    methods % Implementation
+
+        % Domain
+
+        function g = sample(self)
+            g = self.niceMorphism.preimageElement(self.niceGroup.sample);
+            % TODO: optimize
+        end
+
+        % FiniteSet
+
+        % FiniteGroup
 
         % Group elements
 
@@ -158,10 +168,6 @@ classdef NiceFiniteGroup < replab.FiniteGroup
             if nargin > 3 && ~isempty(niceGroup)
                 sub.cache('niceGroup', niceGroup, '==');
             end
-        end
-
-        function sub = computeDerivedSubgroup(self)
-            sub = self.niceMorphism.preimageGroup(self.niceGroup.derivedSubgroup);
         end
 
         function sub1 = centralizer(self, obj)

--- a/src/+replab/NormalCoset.m
+++ b/src/+replab/NormalCoset.m
@@ -26,6 +26,14 @@ classdef NormalCoset < replab.LeftCoset & replab.RightCoset
 
     end
 
+    methods (Access = protected)
+
+        function E = computeElements(self)
+            E = computeElements@replab.LeftCoset(self);
+        end
+
+    end
+
     methods
 
         function s = sample(self)
@@ -38,10 +46,6 @@ classdef NormalCoset < replab.LeftCoset & replab.RightCoset
 
         function b = contains(self, el)
             b = contains@replab.LeftCoset(self, el);
-        end
-
-        function E = computeElements(self)
-            E = computeElements@replab.LeftCoset(self);
         end
 
     end

--- a/src/+replab/Obj.m
+++ b/src/+replab/Obj.m
@@ -50,6 +50,7 @@ classdef Obj < replab.Str
         % - ``ignore``: The existing value is left unchanged
         % - ``isequal``: The existing value and the given value are compared for equality using ``isequal``
         % - ``=``: The existing value and the given value are compared for equality using ``==``
+        % - ``error``: Raises an error
         %
         % Args:
         %   name (charstring): Name of the property
@@ -63,6 +64,8 @@ classdef Obj < replab.Str
                     handleExisting = 'ignore';
                 end
                 switch handleExisting
+                  case 'error'
+                    error('Value for %s already present in cache', name);
                   case 'overwrite'
                     self.cache_.(name) = value;
                   case 'ignore'

--- a/src/+replab/RightCoset.m
+++ b/src/+replab/RightCoset.m
@@ -36,6 +36,28 @@ classdef RightCoset < replab.Coset
 
     end
 
+    methods (Access = protected)
+
+        function E = computeElements(self)
+        % Returns an indexed family of the elements of this coset
+        %
+        % Returns:
+        %   `+replab.IndexedFamily`: Elements
+            H = self.groupChain.allElements;
+            g = self.representative;
+            if ~isempty(self.isomorphism)
+                g = self.isomorphism.imageElement(g);
+            end
+            matrix = zeros(size(H));
+            for i = 1:size(H, 2)
+                matrix(:,i) = H(g,i);
+            end
+            matrix = sortrows(matrix')';
+            E = replab.indf.FiniteGroupIndexedFamily(matrix, self.isomorphism);
+        end
+
+    end
+
     methods % Implementations
 
         % Domain
@@ -67,24 +89,6 @@ classdef RightCoset < replab.Coset
             end
             el = replab.bsgs.Cosets.rightRepresentative(self.groupChain, el);
             b = isequal(self.representative, el);
-        end
-
-        function E = computeElements(self)
-        % Returns an indexed family of the elements of this coset
-        %
-        % Returns:
-        %   `+replab.IndexedFamily`: Elements
-            H = self.groupChain.allElements;
-            g = self.representative;
-            if ~isempty(self.isomorphism)
-                g = self.isomorphism.imageElement(g);
-            end
-            matrix = zeros(size(H));
-            for i = 1:size(H, 2)
-                matrix(:,i) = H(g,i);
-            end
-            matrix = sortrows(matrix')';
-            E = replab.indf.FiniteGroupIndexedFamily(matrix, self.isomorphism);
         end
 
     end

--- a/src/+replab/SignedSymmetricGroup.m
+++ b/src/+replab/SignedSymmetricGroup.m
@@ -48,7 +48,7 @@ classdef SignedSymmetricGroup < replab.SignedPermutationGroup
 
     end
 
-    methods % Property computation
+    methods (Access = protected)
 
         function o = computeOrder(self)
             o = factorial(vpi(self.domainSize)) * vpi(2)^self.domainSize;

--- a/src/+replab/Str.m
+++ b/src/+replab/Str.m
@@ -34,7 +34,7 @@ classdef Str < handle
 %     ans =
 %     'Symmetric group acting on 3 elements'
 
-    methods
+    methods % Prettyprinting
 
         function disp(self)
         % Standard MATLAB/Octave display method

--- a/src/+replab/SymmetricGroup.m
+++ b/src/+replab/SymmetricGroup.m
@@ -107,7 +107,7 @@ classdef SymmetricGroup < replab.PermutationGroup
 
     end
 
-    methods % Property computation
+    methods (Access = protected)
 
         function o = computeOrder(self)
             o = factorial(vpi(self.domainSize));
@@ -123,11 +123,6 @@ classdef SymmetricGroup < replab.PermutationGroup
             G = self.subgroup(self.generators, self.order);
             d = G.decomposition;
         end
-
-    end
-
-    methods (Access = protected)
-
 
         function ind = enumeratorFind(self, g)
             n = self.domainSize;


### PR DESCRIPTION
This needs documentation.

In particular, document that:

- `(Abstract)` is stripped from group names
- `Implementations` is removed as it pertains to implementations of abstract methods

We also need to use the method groups when generating the Sphinx documentation.
