### PR TITLE
Do not precompute the SymmetricGroup order

### DIFF
--- a/src/+replab/SymmetricGroup.m
+++ b/src/+replab/SymmetricGroup.m
@@ -14,7 +14,6 @@ classdef SymmetricGroup < replab.PermutationGroup
         %
         % Args:
         %   domainSize (integer): Domain size, must be > 0
-            o = replab.util.multiplyIntegers(1:domainSize);
             if domainSize < 2
                 generators = cell(1, 0);
             elseif domainSize == 2
@@ -22,7 +21,7 @@ classdef SymmetricGroup < replab.PermutationGroup
             else
                 generators = {[2:domainSize 1] [2 1 3:domainSize]};
             end
-            self = self@replab.PermutationGroup(domainSize, generators, o, 'self');
+            self = self@replab.PermutationGroup(domainSize, generators, [], 'self');
         end
 
     end
@@ -109,8 +108,13 @@ classdef SymmetricGroup < replab.PermutationGroup
 
     methods (Access = protected)
 
+        function c = computeChain(self)
+            self.order; % force order computation
+            c = computeChain@replab.PermutationGroup(self);
+        end
+
         function o = computeOrder(self)
-            o = factorial(vpi(self.domainSize));
+            o = replab.util.multiplyIntegers(1:self.domainSize);
         end
 
         function E = computeElements(self)


### PR DESCRIPTION
as we can use pretty large symmetric groups for the `type`.