### PR TITLE
Find (iso/epi)morphisms between groups

### DIFF
--- a/src/+replab/+mrp/FindMorphisms.m
+++ b/src/+replab/+mrp/FindMorphisms.m
@@ -1,0 +1,140 @@
+classdef FindMorphisms
+% Search for morphisms between groups up to conjugation
+%
+% Implements EPIMORPHISMS from
+% D. Holt et al., Handbook of Computational Group Theory, Chapman & Hall/CRC, 2004, pp. 325-332
+
+
+    properties (SetAccess = protected)
+        r % (integer): Number of generators in `.F`
+        F % (`+replab.AbstractGroup`): Abstract group to find homomorphisms from
+        G % (`+replab.FiniteGroup`): Finite group to find homomorphisms to
+        A % (`+replab.FiniteGroup`): Supergroup of `.G`
+        I % (cell(1,r) of cell(1,\*) of elements of `.G`): Candidates
+        CI % (cell(1,r) of cell(1,\*) of `+replab.FiniteGroup`): Candidates centralizers in `.A`
+        relatorLetters % (cell(1,\*) of integer(1,\*)): Relators of F in letter form
+        relatorSubsets % (integer(1,nFGens)): How many relators contain only the first ``k`` generators, see line 1 of EPIMORPHISMS
+        filter % ({'morphisms', 'epimorphisms', 'isomorphisms'): Whether to look for morphisms, epimorphisms, isomorphisms
+    end
+
+    methods
+
+        function self = FindMorphisms(F, G, A, filter)
+        % Constructor
+            assert(G == A); % for now, contact D. Holt to know how to compute representative of conjugacy classes in subgroups
+            r = F.nGenerators;
+            h = cellfun(@(c) c.representative, G.conjugacyClasses.classes, 'uniform', 0);
+            Ch = cellfun(@(c) c.representativeCentralizer, G.conjugacyClasses.classes, 'uniform', 0);
+            heo = cellfun(@(g) G.elementOrder(g), h);
+            I = cell(1, r);
+            CI = cell(1, r);
+            relatorLetters = cellfun(@(rel) F.factorizeLetters(rel), F.relators, 'uniform', 0);
+            relmax = cellfun(@(rl) max(abs(rl)), relatorLetters);
+            for i = 1:r
+                relatorSubsets(i) = find([relmax > i, true], 1) - 1;
+            end
+            for i = 1:r
+                t = 0;
+                for j = 1:length(relatorLetters)
+                    rel = relatorLetters{j};
+                    if all(abs(rel) == i)
+                        t = gcd(t, sum(sign(rel)));
+                    end
+                end
+                Ii = cell(1, 0);
+                CIi = cell(1, 0);
+                for j = 1:length(h)
+                    if isequal(filter, 'isomorphisms')
+                        condition = t == heo(j);
+                    else
+                        condition = mod(t, heo(j)) == 0;
+                    end
+                    if condition
+                        Ii{1,end+1} = h{j};
+                        CIi{1,end+1} = Ch{j};
+                    end
+                end
+                I{i} = Ii;
+                CI{i} = CIi;
+            end
+            self.r = r;
+            self.F = F;
+            self.G = G;
+            self.A = A;
+            self.I = I;
+            self.CI = CI;
+            self.relatorLetters = relatorLetters;
+            self.relatorSubsets = relatorSubsets;
+            self.filter = filter;
+        end
+
+        function res = search(self)
+            I1 = self.I{1};
+            CI1 = self.CI{1};
+            res = cell(1, 0);
+            % At first level, we do not need to conjugate the candidates, because we are looking for morphisms up to conjugation
+            for i = 1:length(I1)
+                g1 = I1{i};
+                Cg1 = CI1{i};
+                res1 = self.rec(2, {Cg1}, {g1}, {self.A.identity}, {g1});
+                res = horzcat(res, res1);
+            end
+        end
+
+        function res = testRelators(self, k, im)
+        % Tests the relators for the given partial generator array
+            res = false;
+            for i = 1:self.relatorSubsets(k)
+                if ~self.G.isIdentity(self.G.composeLetters(im, self.relatorLetters{i}))
+                    return
+                end
+            end
+            res = true;
+        end
+
+        function res = rec(self, k, Lambda, g, alpha, im)
+        % Searchs for epimorphisms
+        %
+        % Note that our definition of conjugacy is such that conjugacy is a left action; thus we need to reverse some definitions.
+        %
+        % Args:
+        %   k (integer, > 1): Level to investigate
+        %   Lambda (cell(1,k-1) of `+replab.FiniteGroup`): Intersection of centralizers as per description in p. 329, Holt
+        %   g (cell(1,k-1) of elements of `.G`): Partial list of generator candidates
+        %   alpha (cell(1,k-1) of elements of `.A`): Conjugating elements
+        %   im (cell(1,k-1) of elements of `.G`): Partial list of generators
+            res = cell(1, 0);
+            if k > self.r
+                if ~isequal(self.filter, 'morphisms')
+                    IM = self.G.subgroup(im);
+                    if IM.order ~= self.G.order
+                        return % empty res
+                    end
+                end
+                res = {self.F.morphismByImages(self.G, 'preimages', self.F.generators, 'images', im)};
+                return
+            end
+            Ik = self.I{k};
+            CIk = self.CI{k};
+            for i = 1:length(Ik)
+                gk = Ik{i};
+                Cgk = CIk{i};
+                delta = self.A.doubleCosets(Lambda{k-1}, Cgk).transversal;
+                for j = 1:length(delta)
+                    deltaj = delta{j};
+                    g{k} = gk;
+                    alpha{k} = deltaj;
+                    im{k} = self.A.leftConjugate(deltaj, gk);
+                    if self.testRelators(k, im)
+                        Lkprev = Lambda{k-1};
+                        Lambda{k} = Lkprev.centralizer(im{k});
+                        res1 = self.rec(k + 1, Lambda, g, alpha, im);
+                        res = horzcat(res, res1);
+                    end
+                end
+            end
+        end
+
+    end
+
+end

--- a/src/+replab/+mrp/FindMorphisms.m
+++ b/src/+replab/+mrp/FindMorphisms.m
@@ -68,7 +68,21 @@ classdef FindMorphisms
             self.filter = filter;
         end
 
-        function res = search(self)
+        function res = searchAll(self)
+            red = self.searchUpToConjugation;
+            res = cell(1, 0);
+            for i = 1:length(red)
+                f = red{i};
+                G = f.image;
+                innerElements = G/G.center;
+                innerElements = innerElements.transversal;
+                for i = 1:length(innerElements)
+                    res{1,end+1} = f.andThen(G.conjugatingAutomorphism(innerElements{i}));
+                end
+            end
+        end
+
+        function res = searchUpToConjugation(self)
             I1 = self.I{1};
             CI1 = self.CI{1};
             res = cell(1, 0);

--- a/src/+replab/+mrp/FindMorphisms.m
+++ b/src/+replab/+mrp/FindMorphisms.m
@@ -131,7 +131,7 @@ classdef FindMorphisms
                         return % empty res
                     end
                 end
-                res = {self.F.morphismByImages(self.G, 'preimages', self.F.generators, 'images', im)};
+                res = {self.F.morphismByImages(self.G, 'preimages', self.F.generators, 'images', im, 'nChecks', 0)};
                 return
             end
             Ik = self.I{k};

--- a/src/+replab/+mrp/FindMorphisms.m
+++ b/src/+replab/+mrp/FindMorphisms.m
@@ -15,11 +15,12 @@ classdef FindMorphisms
         relatorLetters % (cell(1,\*) of integer(1,\*)): Relators of F in letter form
         relatorSubsets % (integer(1,nFGens)): How many relators contain only the first ``k`` generators, see line 1 of EPIMORPHISMS
         filter % ({'morphisms', 'epimorphisms', 'isomorphisms'): Whether to look for morphisms, epimorphisms, isomorphisms
+        single % (logical): Whether to return only the first result
     end
 
     methods
 
-        function self = FindMorphisms(F, G, A, filter)
+        function self = FindMorphisms(F, G, A, filter, single)
         % Constructor
             assert(G == A); % for now, contact D. Holt to know how to compute representative of conjugacy classes in subgroups
             r = F.nGenerators;
@@ -66,9 +67,11 @@ classdef FindMorphisms
             self.relatorLetters = relatorLetters;
             self.relatorSubsets = relatorSubsets;
             self.filter = filter;
+            self.single = single;
         end
 
         function res = searchAll(self)
+            assert(~self.single);
             red = self.searchUpToConjugation;
             res = cell(1, 0);
             for i = 1:length(red)
@@ -92,6 +95,9 @@ classdef FindMorphisms
                 Cg1 = CI1{i};
                 res1 = self.rec(2, {Cg1}, {g1}, {self.A.identity}, {g1});
                 res = horzcat(res, res1);
+                if self.single && ~isempty(res)
+                    return
+                end
             end
         end
 
@@ -144,6 +150,9 @@ classdef FindMorphisms
                         Lambda{k} = Lkprev.centralizer(im{k});
                         res1 = self.rec(k + 1, Lambda, g, alpha, im);
                         res = horzcat(res, res1);
+                        if self.single && ~isempty(res)
+                            return
+                        end
                     end
                 end
             end

--- a/src/+replab/+sym/CGTest.m
+++ b/src/+replab/+sym/CGTest.m
@@ -1,8 +1,6 @@
-clebschGordanTest
-
-function clebschGordanTest
+function CGTest
     S5 = replab.S(5);
-    [~,mat1,irreps1]  =replab.sym.findAllCGCoeffs(S5,[4 1],[3 1 1],0); 
+    [~,mat1,irreps1]  =replab.sym.findAllCGCoeffs(S5,[4 1],[3 1 1],0);
     %Testing of floating point orthogonal decomp
     rep1 = kron(S5.irrep([4 1],'orthogonal'),S5.irrep([3 1 1],'orthogonal'));
     assert(isdiag(removeZeroErrors(mat1'*rep1.commutant.sample*mat1)));
@@ -10,22 +8,22 @@ function clebschGordanTest
     isequal(f,irreps1);
     assert(isequal(f,irreps1));
     assert(norm(mat1*mat1'-eye(rep1.dimension))<1e-14);
-    
-    
+
+
     %Test of slightly higher dimensions and general orthogonal decomp
     S3 = replab.S(3);
     rep2 = kron(S3.naturalRep,S3.naturalRep,S3.naturalRep);
-    [~,mat2,irreps2]  =replab.sym.findAllRepCoeffs(rep2,0); 
+    [~,mat2,irreps2]  =replab.sym.findAllRepCoeffs(rep2,0);
     assert(nnz(removeZeroErrors(mat2'*rep2.commutant.sample*mat2))==203);
     f = intPartList({[3],[2 1],[1 1 1]});
     assert(isequal(f,irreps2));
     assert(norm(mat2*mat2'-eye(rep2.dimension))<1e-14);
-    
-    
+
+
     %Test of symbolic general decomp
     S6 = replab.S(6);
     rep2 = kron(S6.naturalRep);
-    [~,mat3,~]  =replab.sym.findAllRepCoeffs(rep2,1); 
+    [~,mat3,~]  =replab.sym.findAllRepCoeffs(rep2,1);
     numerTest = [1    -1    -6    -3    -2    -3;...
      1    -1    -6    -3    -2     3;...
      1    -1    -6    -3     4     0;...

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -891,6 +891,22 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
 
     methods % Morphisms
 
+        function res = findIsomorphism(self, to)
+        % Finds an isomorphism from this finite group to another finite group, if it exists
+        %
+        % Args:
+        %   to (`+replab.FiniteGroup`): Target of the isomorphism
+        %
+        % Returns:
+        %   `.FiniteIsomorphism` or ``[]``: The isomorphism if it exists, or an empty array
+            res = self.findIsomorphisms(to, 'single', true, 'upToConjugation', true);
+            if ~isempty(res)
+                res = res{1};
+            else
+                res = [];
+            end
+        end
+
         function res = findIsomorphisms(self, to, varargin)
         % Finds all the isomorphisms from this finite group to another finite group
         %

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -899,16 +899,17 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         %
         % Keyword Args:
         %   upToConjugation (logical, optional): Whether to list morphisms up to conjugation of the image group, default: false
+        %   single (logical, optoinal): Whether to return maximum a single result, default: false
         %
         % Returns:
         %   cell(1,\*) of `.FiniteIsomorphism`: The morphisms
-            args = struct('upToConjugation', false);
+            args = struct('upToConjugation', false, 'single', false);
             args = replab.util.populateStruct(args, varargin);
             F = self.abstractGroup;
             G = to;
             A = to;
-            fm = replab.mrp.FindMorphisms(F, G, A, 'isomorphisms');
-            if args.upToConjugation
+            fm = replab.mrp.FindMorphisms(F, G, A, 'isomorphisms', args.single);
+            if args.upToConjugation || args.single
                 res = fm.searchUpToConjugation;
             else
                 res = fm.searchAll;
@@ -925,14 +926,15 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         % Keyword Args:
         %   upToConjugation (logical, optional): Whether to list morphisms up to conjugation of the image group, default: false
         %   surjective (logical, optional): Whether to consider only surjective morphisms (or epimorphisms), whose image span ``to``, default: true
+        %   single (logical, optoinal): Whether to return maximum a single result, default: false
         %
         % Returns:
         %   cell(1,\*) of `.FiniteMorphism`: The morphisms
-            args = struct('upToConjugation', false, 'surjective', true);
+            args = struct('upToConjugation', false, 'surjective', true, 'single', false);
             args = replab.util.populateStruct(args, varargin);
             if args.surjective
                 if self.order == to.order
-                    res = self.findIsomorphisms(to, 'upToConjugation', args.upToConjugation);
+                    res = self.findIsomorphisms(to, 'upToConjugation', args.upToConjugation, 'single', args.single);
                     return
                 else
                     filter = 'epimorphisms';
@@ -943,8 +945,8 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
             F = self.abstractGroup;
             G = to;
             A = to;
-            fm = replab.mrp.FindMorphisms(F, G, A, filter);
-            if args.upToConjugation
+            fm = replab.mrp.FindMorphisms(F, G, A, filter, args.single);
+            if args.upToConjugation || args.single
                 res = fm.searchUpToConjugation;
             else
                 res = fm.searchAll;

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -908,9 +908,12 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         %   single (logical, optoinal): Whether to return maximum a single result, default: false
         %
         % Returns:
-        %   cell(1,\*) of `.FiniteIsomorphism`: The morphisms
+        %   cell(1,\*) of `.FiniteIsomorphism`: The isomorphisms
             args = struct('upToConjugation', false, 'single', false);
             args = replab.util.populateStruct(args, varargin);
+            if args.single
+                args.upToConjugation = true;
+            end
             F = self.abstractGroup;
             G = to;
             A = to;
@@ -945,6 +948,9 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         %   cell(1,\*) of `.FiniteMorphism`: The morphisms
             args = struct('upToConjugation', false, 'surjective', false, 'single', false);
             args = replab.util.populateStruct(args, varargin);
+            if args.single
+                args.upToConjugation = true;
+            end
             if args.surjective
                 if self.order == to.order
                     res = self.findIsomorphisms(to, 'upToConjugation', args.upToConjugation, 'single', args.single);

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -926,17 +926,24 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         function res = findMorphisms(self, to, varargin)
         % Finds all the morphisms from this finite group to another finite group
         %
+        % Example:
+        %   >>> S3 = replab.S(3);
+        %   >>> S4 = replab.S(4);
+        %   >>> m = S4.findMorphisms(S3, 'upToConjugation', true, 'surjective', false);
+        %   >>> length(m)
+        %       3
+        %
         % Args:
         %   to (`+replab.FiniteGroup`): Target of the morphism
         %
         % Keyword Args:
         %   upToConjugation (logical, optional): Whether to list morphisms up to conjugation of the image group, default: false
-        %   surjective (logical, optional): Whether to consider only surjective morphisms (or epimorphisms), whose image span ``to``, default: true
+        %   surjective (logical, optional): Whether to consider only surjective morphisms (or epimorphisms), whose image span ``to``, default: false
         %   single (logical, optoinal): Whether to return maximum a single result, default: false
         %
         % Returns:
         %   cell(1,\*) of `.FiniteMorphism`: The morphisms
-            args = struct('upToConjugation', false, 'surjective', true, 'single', false);
+            args = struct('upToConjugation', false, 'surjective', false, 'single', false);
             args = replab.util.populateStruct(args, varargin);
             if args.surjective
                 if self.order == to.order

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -894,6 +894,12 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         function res = findIsomorphisms(self, to, varargin)
         % Finds all the isomorphisms from this finite group to another finite group
         %
+        % Example:
+        %   >>> G = replab.S(6);
+        %   >>> m = G.findIsomorphisms(G, 'upToConjugation', true);
+        %   >>> length(m)
+        %       2
+        %
         % Args:
         %   to (`+replab.FiniteGroup`): Target of the isomorphism
         %

--- a/src/+replab/FiniteGroup.m
+++ b/src/+replab/FiniteGroup.m
@@ -977,7 +977,7 @@ classdef FiniteGroup < replab.CompactGroup & replab.FiniteSet
         %   `+replab.FiniteMorphism`: Conjugating automorphism
             generatorImages = cellfun(@(g) self.type.leftConjugate(by, g), self.generators, 'uniform', 0);
             assert(all(cellfun(@(g) self.contains(g), generatorImages)));
-            m = self.morphismByImages(self, 'preimages', self.generators, 'images', generatorImages);
+            m = self.morphismByImages(self, 'preimages', self.generators, 'images', generatorImages, 'nChecks', 0);
         end
 
         function f = niceMorphism(self)

--- a/src/+replab/FiniteMorphism.m
+++ b/src/+replab/FiniteMorphism.m
@@ -3,6 +3,16 @@ classdef FiniteMorphism < replab.Morphism
 
     methods % Implementations
 
+        % Str
+
+        function [names values] = additionalFields(self)
+            [names values] = additionalFields@replab.Morphism(self);
+            for i = 1:self.source.nGenerators
+                names{1, end+1} = sprintf('imageElement(%s)', replab.shortStr(self.source.generator(i)));
+                values{1, end+1} = self.imageElement(self.source.generator(i));
+            end
+        end
+
         % Obj
 
         function l = laws(self)


### PR DESCRIPTION
This implements the algorithm EPIMORPHISMS described in Holt, Handbook of Computational Group Theory.