### PR TITLE
Issue#451

### DIFF
--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -579,7 +579,35 @@ classdef PermutationGroup < replab.FiniteGroup
         %
         % Returns:
         %   `.PermutationGroup`: The subgroup that stabilizes the ordered partition
-            sub = replab.bsgs.OrderedPartitionStabilizer(self, partition).subgroup;
+
+            % We compute explicitely the group that leaves each partition
+            % block invariant
+            generators = {};
+            for i = 1:partition.nBlocks
+                switch length(partition.block(i))
+                    case 1
+                        % No generator
+                    case 2
+                        % 1 generator
+                        block = sort(partition.block(i));
+                        generator = 1:self.domainSize;
+                        generator(block) = generator(block([2 1]));
+                        generators{end+1} = generator;
+                    otherwise
+                        % 2 generators
+                        block = sort(partition.block(i));
+                        generator = 1:self.domainSize;
+                        generator(block([1 2])) = generator(block([2 1]));
+                        generators{end+1} = generator;
+                        generator = 1:self.domainSize;
+                        generator(block) = generator(block([2:end, 1]));
+                        generators{end+1} = generator;
+                end
+            end
+            invarGroup = replab.S(self.domainSize).subgroup(generators);
+            
+            % Now we take the intersection between both groups
+            sub = self.intersection(invarGroup);
         end
 
         function P = vectorFindPermutationsTo(self, s, t, sStabilizer, tStabilizer)

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -604,7 +604,8 @@ classdef PermutationGroup < replab.FiniteGroup
                         generators{end+1} = generator;
                 end
             end
-            invarGroup = replab.S(self.domainSize).subgroup(generators);
+            Sn = replab.S(self.domainSize);
+            invarGroup = Sn.subgroup(generators);
             
             % Now we take the intersection between both groups
             sub = self.intersection(invarGroup);

--- a/src/+replab/UndirectedGraph.m
+++ b/src/+replab/UndirectedGraph.m
@@ -63,10 +63,10 @@ classdef UndirectedGraph < replab.graph.Graph
         % weights was defined individually for each edge.
         %
         % Args:
-        %     edges (integer (\*,2)): array of vertices linked by an edge
-        %     nVertices (integer, optional): number of vertices
-        %     colors (double (\*,1), optional): coloring of the vertices
-        %     weights (double (\*,1), optional): weight associated to each edge
+        %   edges (integer (\*,2)): array of vertices linked by an edge
+        %   nVertices (integer, optional): number of vertices
+        %   colors (double (\*,1), optional): coloring of the vertices
+        %   weights (double (\*,1), optional): weight associated to each edge
         %
         % Returns:
         %   graph (`.UndirectedGraph`)
@@ -108,7 +108,7 @@ classdef UndirectedGraph < replab.graph.Graph
             self = replab.UndirectedGraph(nVertices, edges, colors, weights);
         end
 
-        function self = fromBiadjacencyMatrix(biadj)
+        function self = fromBiadjacencyMatrix(biadj, colorsRows, colorsCols)
         % Constructs an undirected graph from a biadjacency matrix
         %
         % A bipartite undirected graph is one in which vertices can
@@ -123,6 +123,8 @@ classdef UndirectedGraph < replab.graph.Graph
         %
         % Args:
         %   biadj(double (\*,\*)): array of vertices linked by an edge
+        %   colors (double (\*,1), optional): coloring of the row vertices
+        %   colors (double (\*,1), optional): coloring of the column vertices
         %
         % Returns:
         %   graph (`.UndirectedGraph`)
@@ -132,11 +134,25 @@ classdef UndirectedGraph < replab.graph.Graph
         %     Undirected graph with 5 vertices and 4 edges
         %     edges: [1, 3; 2, 3; 2, 4; 1, 5]
 
+            if nargin < 2
+                colorsRows = zeros(1, size(biadj,1));
+            end
+            
+            if nargin < 3
+                colorsCols = zeros(1, size(biadj,2));
+            end
+                        
             % Construct the associated full adjacency matrix
             adj = [zeros(size(biadj,1)*[1 1]), biadj;
                    zeros(size(biadj,2), sum(size(biadj)))];
-               
-            self = replab.UndirectedGraph.fromAdjacencyMatrix(adj);
+            
+            % Carry over the coloring if it was provided
+            colors = [colorsRows(:); colorsCols(:)].';
+            if isequal(colors, zeros(1, sum(size(biadj))))
+                colors = 0;
+            end
+
+            self = replab.UndirectedGraph.fromAdjacencyMatrix(adj, colors);
         end
 
         function self = fromDirectedGraph(graph)


### PR DESCRIPTION
Here is a temporary fix to this issue. The group stabilizing a partition is computed by explicitly listing its generators, which is very fast. Then we perform a group intersection. In particular, this procedure seems to behave well when either group is trivial or S(n). What do you think @denisrosset ?