### PR TITLE
Separate checks for some good SDP solver, and SDPT3 (if needed)

### DIFF
--- a/replab_config.m
+++ b/replab_config.m
@@ -13,7 +13,10 @@ replab.init.initHelp;
 
 % Support for the convex modeling framework and SDP solvers
 replab.init.YALMIP().require;
-replab.init.sdpt3().require;
+if ~replab.init.existingSdpSolver().works
+    replab.init.log_(2, 'Trying to use the embedded solver');
+    replab.init.sdpt3().require;
+end
 
 % This can be commented out if you're not decomposing representations of compact groups
 replab.init.nlinfit().require;

--- a/replab_init.m
+++ b/replab_init.m
@@ -110,7 +110,6 @@ function replab_init(varargin)
         end
     end
 
-
     %% Memorizing RepLAB root folder if not done before
     rgrp = replab.globals.replabPath;
     if isempty(rgrp)
@@ -121,13 +120,11 @@ function replab_init(varargin)
         % path already memorized
     end
 
-    %% Sets the initialization verbosity level
-
+    %% Memorizing the options
     replab.globals.verboseInit(verbose);
     replab.globals.autoInstall(autoinstall);
 
     %% Run the config script
-
     if showurls
         replab.init.showUrls;
     else

--- a/src/+replab/+init/existingSdpSolver.m
+++ b/src/+replab/+init/existingSdpSolver.m
@@ -1,0 +1,52 @@
+classdef existingSdpSolver < replab.init.Dependency
+% Checks whether a good and working SDP solver is already available
+
+    methods
+
+        function self = existingSdpSolver
+            self.name = 'existingSdpSolver';
+        end
+
+        function res = inPath(self)
+            res = true;
+        end
+
+        function decentSDPSolverInPath = works(self)
+            decentSDPSolverInPath = false;
+            try
+                x = sdpvar(2);
+                F = [x >= 0, trace(x) == 1];
+                [interfacedata,recoverdata,solver,diagnostic] = compileinterfacedata(F, [], [], [], sdpsettings, 0, 0);
+                decentSDPSolverInPath = isempty(diagnostic);
+
+                % If LMILAB was identified as the best solver to solve the
+                % problem, this means that no good solver was found.
+                if ~isempty(strfind(upper(solver.tag), 'LMILAB'))
+                    decentSDPSolverInPath = false;
+                end
+
+                % If a decent solver was found, we make sure it can actually
+                % solve an SDP (e.g. the license is valid ;-)
+                if decentSDPSolverInPath
+                    sol = solvesdp(F, x(1,2), sdpsettings('verbose',0));
+                    if isempty(sol) || ~isequal(sol.problem, 0)
+                        decentSDPSolverInPath = false;
+                        if replab.globals.verboseInit >= 2
+                            disp(['The solver ', solver.tag, ' was found, but it produced the following error when called']);
+                            disp('to solve and SDP:');
+                            disp(['    ', sol.info]);
+                        end
+                    else
+                        replab.init.log_(2, ['Working SDP solver ', solver.tag, ' found in path']);
+                    end
+                end
+            catch
+            end
+        end
+
+        function init(self, folderName)
+        end
+
+    end
+
+end

--- a/src/+replab/+init/sdpt3.m
+++ b/src/+replab/+init/sdpt3.m
@@ -6,7 +6,7 @@ classdef sdpt3 < replab.init.ExternalDependency
             self@replab.init.ExternalDependency('sdpt3', 'sdpt3.m');
         end
 
-        function res = sdpt3_works(self)
+        function res = works(self)
             res = false;
             try
                 [blk, Avec, C, b, X0, y0, Z0] = randsdp([2 2], [2 2], 2, 2);
@@ -19,40 +19,7 @@ classdef sdpt3 < replab.init.ExternalDependency
 
 
         function res = inPath(self)
-            assert(exist('compileinterfacedata') == 2, 'Needs to have YALMIP in the path');
-            x = sdpvar(2);
-            F = [x >= 0, trace(x) == 1];
-            [interfacedata,recoverdata,solver,diagnostic] = compileinterfacedata(F, [], [], [], sdpsettings, 0, 0);
-            res = isempty(diagnostic);
-            if ~isempty(strfind(upper(solver.tag), 'LMILAB'))
-                % If LMILAB was identified as the best solver to solve the problem, this means that no good solver was found.
-                res = false;
-            end
-        end
-
-        function res = works(self)
-            res = false;
-            x = sdpvar(2);
-            F = [x >= 0, trace(x) == 1];
-            [interfacedata,recoverdata,solver,diagnostic] = compileinterfacedata(F, [], [], [], sdpsettings, 0, 0);
-            if ~isempty(diagnostic)
-                return
-            end
-            if ~isempty(strfind(upper(solver.tag), 'LMILAB'))
-                replab.init.log_(2, 'LMILAB is not an appropriate SDP solver');
-                return
-            end
-            sol = solvesdp(F, x(1, 2), sdpsettings('verbose', 0));
-            if isempty(sol) || sol.problem ~= 0
-                if replab.globals.verboseInit >= 2
-                    disp(['The solver ', solver.tag, ' was found, but it produced the following error when called']);
-                    disp('to solve and SDP:');
-                    disp(['    ', sol.info]);
-                    disp('Trying to use the embedded solver instead.');
-                end
-                return
-            end
-            res = true;
+            res = exist('sdpt3.m') == 2;
         end
 
         function init(self, path)


### PR DESCRIPTION
SDP solver setup. The idea is to make sure we have a working SDP solver to pass the tests in `replab_runtests`. This should work ideally:
- whether the user already has a good solver in his path or not (in which case use it to avoid altering his setup), 
- even if the user's solver has no valid license anymore (in this case we use our embedded solver)
- if the user doesn't know what an SDP solver is of course