### PR TITLE
Minimal lexicographic representative under a permutation group

### DIFF
--- a/src/+replab/+bsgs/LexMin.m
+++ b/src/+replab/+bsgs/LexMin.m
@@ -1,0 +1,93 @@
+classdef LexMin < replab.Obj
+% Finds the minimal lexicographic representative of a list under the action of a permutation group
+
+    properties (SetAccess = protected)
+        degree % (integer): Domain size, length of `.vec`
+        lexChain % (`+replab.+bsgs.Chain`): BSGS chain with base in lexicographic order
+        G % (`.PermutationGroup`): Group to search in
+        vec % (double(1,\*)): Vector to find the minimal representative of
+        K % (`.PermutationGroup`): Subgroup of `.G` that stabilizes `.vec`
+    end
+
+    methods
+
+        function self = LexMin(G, vec, K)
+            assert(G.domainSize == length(vec));
+            self.G = G;
+            self.lexChain = G.lexChain;
+            self.vec = vec;
+            self.K = K;
+            self.degree = G.domainSize;
+        end
+
+        function [minimal, g] = search(self)
+            self.minimal = zeros(1, self.degree);
+            self.minimalCorrectBefore = 1;
+            self.minimalG = 1:self.degree;
+            for level = 1:length(self.lexChain.B)
+                self.rec(1, level, 1:self.degree);
+            end
+            g = self.G.inverse(self.minimalG);
+            minimal = self.minimal;
+        end
+
+    end
+
+    properties (Access = protected)
+        minimal
+        minimalCorrectBefore
+        minimalG
+    end
+
+    methods (Access = protected)
+
+        function rec(self, level, toLevel, curG)
+            if level <= toLevel
+                chain = self.lexChain;
+                candidates = [];
+                beta = chain.B(level);
+                if level < length(chain.B)
+                    nextBeta = chain.B(level+1);
+                else
+                    nextBeta = self.degree+1;
+                end
+                if nextBeta > self.minimalCorrectBefore
+                    for k = self.minimalCorrectBefore:nextBeta-1
+                        self.minimal(k) = self.vec(self.minimalG(k));
+                    end
+                    self.minimalCorrectBefore = nextBeta;
+                end
+                orbit = chain.Delta{level};
+                for oi = 1:length(orbit)
+                    b = orbit(oi);
+                    bg = curG(b);
+                    comp = self.vec(bg) - self.minimal(beta);
+                    k = beta + 1;
+                    nextG = curG(chain.U{level}(:,oi));
+                    while k < nextBeta && comp == 0
+                        comp = self.vec(nextG(k)) - self.minimal(k);
+                        k = k + 1;
+                    end
+                    if comp <= 0
+                        if comp < 0
+                            for k = beta:self.minimalCorrectBefore-1
+                                self.minimal(k) = self.vec(nextG(k));
+                            end
+                            self.minimalG = nextG;
+                            candidates = [];
+                        end
+                        candidates(end+1) = oi;
+                    end
+                end
+                for oi = candidates
+                    b = orbit(oi);
+                    bg = curG(b);
+                    nextG = curG(chain.U{level}(:,oi));
+                    self.rec(level + 1, toLevel, nextG);
+                end
+            end
+        end
+
+    end
+
+end

--- a/src/+replab/+bsgs/LexMin.m
+++ b/src/+replab/+bsgs/LexMin.m
@@ -21,10 +21,12 @@ classdef LexMin < replab.Obj
         end
 
         function [minimal, g] = search(self)
-            self.minimal = zeros(1, self.degree);
+        % Performs the backtrack search
+            self.minimal = zeros(1, self.degree); % initialize the variables
             self.minimalCorrectBefore = 1;
             self.minimalG = 1:self.degree;
             for level = 1:length(self.lexChain.B)
+                % find lex-minimal prefix of length "level"
                 self.rec(1, level, 1:self.degree, self.vecStabilizer.chain.mutableCopy, 1);
             end
             g = self.G.inverse(self.minimalG);
@@ -42,6 +44,17 @@ classdef LexMin < replab.Obj
     methods (Access = protected)
 
         function rec(self, level, toLevel, curG, stab, stabLevel)
+        % Implements breath-first in the cosets ``G / vecStabilizer``
+        %
+        % It filters elements that do not lead to a minimal lexicographic representative at each step in the stabilizer chain.
+        % It also searchs only one element per coset.
+        %
+        % Args:
+        %   level (integer): Current level
+        %   toLevel (integer): Maximum level to explore
+        %   curG (permutation): Current product of transversals
+        %   stab (`.Chain`): Mutable chain of stabilizers, with changed base
+        %   stabLevel (integer): Current level in the stabilizer chain
             if level <= toLevel
                 chain = self.lexChain;
                 candidates = [];

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -594,7 +594,7 @@ classdef PermutationGroup < replab.FiniteGroup
         %   >>> [sml, P] = G.vectorFindLexMinimal(s);
         %   >>> all(sml == sort(s)) % lexmin using the symmetric group is simply a sort
         %       1
-        %   >>> all(slm(P.representative) == s)
+        %   >>> all(sml(P.representative) == s)
         %       1
         %
         % Args:

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -584,6 +584,37 @@ classdef PermutationGroup < replab.FiniteGroup
             sub = replab.bsgs.OrderedPartitionStabilizer(self, partition).subgroup;
         end
 
+        function [sMinLex, P] = vectorFindLexMinimal(self, s, sStabilizer)
+        % Finds the lexicographic minimal vector under permutation of its coefficients by this group
+        %
+        % Example:
+        %   >>> n = 10;
+        %   >>> s = randi([-3 3], 1, n);
+        %   >>> G = replab.S(n);
+        %   >>> [sml, P] = G.vectorFindLexMinimal(s);
+        %   >>> all(sml == sort(s)) % lexmin using the symmetric group is simply a sort
+        %       1
+        %   >>> all(slm(P.representative) == s)
+        %       1
+        %
+        % Args:
+        %   s (double(1,domainSize)): Vector to permute
+        %   sStabilizer (`.PermutationGroup` or ``[]``, optional): Stabilzier of ``s``
+        %
+        % Returns
+        % -------
+        %   sMinLex: double(1,domainSize):
+        %     Minimal lexicographic representative of ``s`` under permutation by this group
+        %   g: `.LeftCoset`
+        %     Set of permutations ``p`` such that ``sMinLex == s(inverse(p))`` or ``s == sMinLex(p)``
+            if nargin < 3 || isempty(sStabilizer)
+                sStabilizer = self.vectorStabilizer(s);
+            end
+            lm = replab.bsgs.LexMin(self, s, sStabilizer);
+            [sMinLex, p] = lm.search;
+            P = sStabilizer.leftCoset(p, self);
+        end
+
         function P = vectorFindPermutationsTo(self, s, t, sStabilizer, tStabilizer)
         % Finds the permutations that send a vector to another vector
         %

--- a/tests/replab/LexMinTest.m
+++ b/tests/replab/LexMinTest.m
@@ -1,0 +1,32 @@
+function test_suite = LexMinTest()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+function test_lexmin
+    for i = 1:10
+        n = 10;
+        G = replab.S(n);
+        G = G.randomProperSubgroup(3);
+        s1 = randi(3, 1, n);
+        g = G.sample;
+        s2 = s1(g);
+        [smin1, P1] = G.vectorFindLexMinimal(s1);
+        [smin2, P2] = G.vectorFindLexMinimal(s2);
+        assert(all(smin1 == smin2));
+        assert(all(smin1(P1.representative) == s1));
+        assert(all(smin2(P2.representative) == s2));
+    end
+end
+function test_symmetric_group
+    for i = 1:10
+        n = 10;
+        G = replab.S(n);
+        s = randi(3, 1, n);
+        [smin, P] = G.vectorFindLexMinimal(s);
+        assert(all(smin == sort(s)));
+    end
+end

--- a/tests/replab/LexMinTest.m
+++ b/tests/replab/LexMinTest.m
@@ -17,8 +17,8 @@ function test_lexmin
         [smin1, P1] = G.vectorFindLexMinimal(s1);
         [smin2, P2] = G.vectorFindLexMinimal(s2);
         assert(all(smin1 == smin2));
-        assert(all(smin1(P1.representative) == s1));
-        assert(all(smin2(P2.representative) == s2));
+        assert(all(smin1(P1.sample) == s1));
+        assert(all(smin2(P2.sample) == s2));
     end
 end
 function test_symmetric_group


### PR DESCRIPTION
Implements a method `vectorFindLexMinimal` on `PermutationGroup` to find a canonical representative of a vector under permutation of its coefficients by a permutation group.

Fixes #474