### PR TITLE
Use coarse block structure in decomposition

### DIFF
--- a/src/+replab/+rep/ComplexifiedRep.m
+++ b/src/+replab/+rep/ComplexifiedRep.m
@@ -99,6 +99,10 @@ classdef ComplexifiedRep < replab.Rep
             b = self.parent.isExact;
         end
 
+        function p = invariantBlocks(self)
+            p = self.parent.invariantBlocks;
+        end
+
     end
 
 end

--- a/src/+replab/+rep/DefiningRep.m
+++ b/src/+replab/+rep/DefiningRep.m
@@ -33,8 +33,14 @@ classdef DefiningRep < replab.Rep
 
     methods % Implementations
 
+        % Rep
+
         function b = isExact(self)
             b = false; % Note: redundant, as parent is already false
+        end
+
+        function p = invariantBlocks(self)
+            p = replab.Partition.fromBlocks({1:self.dimension});
         end
 
     end

--- a/src/+replab/+rep/DerivedRep.m
+++ b/src/+replab/+rep/DerivedRep.m
@@ -221,6 +221,10 @@ classdef DerivedRep < replab.Rep
             b = self.parent.isExact;
         end
 
+        function p = invariantBlocks(self)
+            p = self.parent.invariantBlocks; % the block structure does not change
+        end
+
         function res = dual(self)
             res = replab.rep.DerivedRep(self.parent, self.conjugate, ~self.inverse, ~self.transpose);
         end

--- a/src/+replab/+rep/DirectSumRep.m
+++ b/src/+replab/+rep/DirectSumRep.m
@@ -1,7 +1,7 @@
 classdef DirectSumRep < replab.Rep
 % A direct sum of representations, such that images are diagonal by blocks
 
-    properties
+    properties (SetAccess = protected)
         factors % (cell(1,\*) of `+replab.Rep`): Contained subrepresentations
     end
 
@@ -221,6 +221,20 @@ classdef DirectSumRep < replab.Rep
 
         function b = isExact(self)
             b = all(cellfun(@(f) f.isExact, self.factors));
+        end
+
+        function p = invariantBlocks(self)
+            if self.nFactors == 0
+                p = replab.Partition(zeros(1, 0), cell(1, 0));
+            else
+                blocks = self.factor(1).invariantBlocks.blocks;
+                shift = self.factor(1).dimension;
+                for i = 2:self.nFactors
+                    newBlocks = cellfun(@(b) b + shift, self.factor(i).invariantBlocks.blocks, 'uniform', 0);
+                    blocks = horzcat(blocks, newBlocks);
+                end
+                p = replab.Partition.fromBlocks(blocks);
+            end
         end
 
     end

--- a/src/+replab/+rep/TensorRep.m
+++ b/src/+replab/+rep/TensorRep.m
@@ -3,7 +3,7 @@ classdef TensorRep < replab.Rep
 %
 % All factor representations must be defined on the same group
 
-    properties
+    properties (SetAccess = protected)
         factors % (cell(1,\*) of `+replab.Rep`): Factor representations
     end
 
@@ -268,6 +268,33 @@ classdef TensorRep < replab.Rep
 
         function b = isExact(self)
             b = all(cellfun(@(f) f.isExact, self.factors));
+        end
+
+        function p = invariantBlocks(self)
+            if self.nFactors == 0
+                p = replab.Partition.fromBlocks({[1]});
+            else
+                dimL = self.factor(1).dimension;
+                blocksL = self.factor(1).invariantBlocks.blocks;
+                for i = 2:self.nFactors
+                    dimR = self.factor(i).dimension;
+                    blocksR = self.factor(i).invariantBlocks.blocks;
+                    res = cell(1, 0);
+                    for l = 1:length(blocksL)
+                        blkL = blocksL{l};
+                        maskL = zeros(1, dimL);
+                        maskL(blkL) = 1;
+                        for r = 1:length(blocksR)
+                            blkR = blocksR{r};
+                            maskR = zeros(1, dimR);
+                            maskR(blkR) = 1;
+                            res{1,end+1} = find(kron(maskL, maskR));
+                        end
+                    end
+                    blocksL = res;
+                end
+                p = replab.Partition.fromBlocks(blocksL);
+            end
         end
 
     end

--- a/src/+replab/+rep/TrivialRep.m
+++ b/src/+replab/+rep/TrivialRep.m
@@ -66,6 +66,12 @@ classdef TrivialRep < replab.Rep
             b = self.isExactValue;
         end
 
+        function p = invariantBlocks(self)
+            blocks = arrayfun(@(i) {i}, 1:self.dimension, 'uniform', 0);
+            % each coordinate in its own block
+            p = replab.Partition.fromBlocks(blocks);
+        end
+
         function complexRep = complexification(self)
             assert(self.overR, 'Representation should be real to start with');
             complexRep = replab.rep.TrivialRep(self.group, 'C', self.dimension);

--- a/src/+replab/Isotypic.m
+++ b/src/+replab/Isotypic.m
@@ -66,7 +66,7 @@ classdef Isotypic < replab.SubRep
                 iso = replab.Isotypic(parent, irreps, irreps{1}.projection_internal, irrepDimension, isHarmonized);
                 return
             end
-            mapsAreUnitary = cellfun(@(s) all(all(s.injection_internal == s.projection_internal')), irreps);
+            mapsAreUnitary = cellfun(@(s) full(all(all(s.injection_internal == s.projection_internal'))), irreps);
             if parent.knownUnitary && all(mapsAreUnitary)
                 % all maps are unitary, parent is unitary, we use orthogonality
                 projections = cell(1, m);

--- a/src/+replab/Rep.m
+++ b/src/+replab/Rep.m
@@ -596,6 +596,35 @@ classdef Rep < replab.Obj
 
     methods % Representation properties
 
+        function p = invariantBlocks(self)
+        % Returns a partition of the set ``1:self.dimension`` such that the subsets of coordinates correspond to invariant spaces
+        %
+        % This method does not guarantee that the finest partition is returned.
+        %
+        % Example:
+        %   >>> G = replab.SignedPermutationGroup.of([1 4 7 2 5 8 3 6 9], [1 -2 -3 -4 5 6 -7 8 9], [1 3 2 4 6 5 -7 -9 -8]);
+        %   >>> rep = G.naturalRep;
+        %   >>> p = rep.invariantBlocks;
+        %   >>> isequal(p.blocks, {[1] [2 3 4 7] [5 6 8 9]})
+        %       1
+        %
+        % Returns:
+        %   `.Partition`: Partition of coarse invariant blocks
+            if isa(self.group, 'replab.FiniteGroup') && self.group.isTrivial
+                blocks = arrayfun(@(i) {i}, 1:self.dimension, 'uniform', 0);
+                % each coordinate in its own block
+                p = replab.Partition.fromBlocks(blocks);
+            elseif isa(self.group, 'replab.FiniteGroup')
+                mask = (self.image(self.group.generator(1)) ~= 0);
+                for i = 2:self.group.nGenerators
+                    mask = mask | (self.image(self.group.generator(i)) ~= 0);
+                end
+                p = replab.UndirectedGraph.fromAdjacencyMatrix(mask).connectedComponents;
+            else
+                p = replab.Partition.fromBlocks({1:self.dimension}); % by default returns one block
+            end
+        end
+
         function kv = knownProperties(self, keys)
         % Returns the known properties among the set of given keys as a key-value cell array
         %


### PR DESCRIPTION
This restores an old RepLAB capability: the use of coarse block structure already present in the representations to decompose.