### PR TITLE
Coset word

### DIFF
--- a/src/+replab/+bsgs/ChainWithWords.m
+++ b/src/+replab/+bsgs/ChainWithWords.m
@@ -176,7 +176,6 @@ classdef ChainWithWords < replab.Str
                         g = g(u);
                         rep = rep(u);
                     end
-                    self.word(rep);
                     b = g(beta);
                 end
                 ind = self.iOrbit(b,i);

--- a/src/+replab/+bsgs/ChainWithWords.m
+++ b/src/+replab/+bsgs/ChainWithWords.m
@@ -88,7 +88,7 @@ classdef ChainWithWords < replab.Str
             end
         end
 
-        function [w, rep] = wordForLeftCoset(self, coset)
+        function [w, rep] = wordCoset(self, coset)
         % Returns a word corresponding to an element of the given coset
         %
         % Notes: If the coset basis leads to another stabilization order
@@ -97,16 +97,18 @@ classdef ChainWithWords < replab.Str
         % within the coset, but without optimality guarantees.
         %
         % Args:
-        %   coset (left coset): Element of `.LeftCoset`
+        %   coset (coset): Element of `.LeftCoset`, `.RightCoset` or `.NormalCoset`
         %
         % Returns:
         % --------
-        %   integer(1,\*): Letters of the word representing an element of ``co``
+        %   integer(1,\*): Letters of the word representing an element
+        %       of ``coset``
         %   integer(1,\*): The member of the coset corresponding to the
         %       word returned
         
             assert(self.completed);
-            assert(isa(coset, 'replab.LeftCoset') || isa(coset, 'replab.NormalCoset'));
+            assert(isa(coset, 'replab.LeftCoset') || isa(coset, 'replab.RightCoset') || isa(coset, 'replab.NormalCoset'));
+            isRightCoset = isa(coset, 'replab.RightCoset');
 
             if coset.group.order == vpi(1)
                 % coset contains a single element, use a simpler method
@@ -162,13 +164,18 @@ classdef ChainWithWords < replab.Str
                         nuw = self.nuw{i}{ind};
                         wordLengths(it) = length(replab.fp.Letters.compose(w, -fliplr(nuw)));
                     end
-                    % Apply a permutation so as to stays in the coset but
+                    % Apply a permutation so as to stay in the coset but
                     % yields a shorter word at this stage
                     bestIt = find(wordLengths == min(wordLengths), 1);
                     Uj = cosetChain.U{j};
                     u = Uj(:, bestIt)';
-                    g = g(u);
-                    rep = rep(u);
+                    if isRightCoset
+                        g = u(g);
+                        rep = u(rep);
+                    else
+                        g = g(u);
+                        rep = rep(u);
+                    end
                     self.word(rep);
                     b = g(beta);
                 end

--- a/src/+replab/+bsgs/ChainWithWords.m
+++ b/src/+replab/+bsgs/ChainWithWords.m
@@ -124,6 +124,7 @@ classdef ChainWithWords < replab.Str
                     stabilizedOrderChain = [stabilizedOrderChain, self.chain.Delta{i}(2)];
                 end
             end
+            stabilizedOrderChain = unique(stabilizedOrderChain, 'stable');
             stabilizedOrderCoset = [];
             for i = 1:length(coset.groupChain.B)
                 stabilizedOrderCoset = [stabilizedOrderCoset, coset.groupChain.B(i)];
@@ -131,6 +132,7 @@ classdef ChainWithWords < replab.Str
                     stabilizedOrderCoset = [stabilizedOrderCoset, coset.groupChain.Delta{i}(2)];
                 end
             end
+            stabilizedOrderCoset = unique(stabilizedOrderCoset, 'stable');
             if isequal(stabilizedOrderChain, stabilizedOrderCoset)
                 % We can use the coset's chain as it is
                 cosetChain = coset.groupChain;
@@ -160,13 +162,14 @@ classdef ChainWithWords < replab.Str
                         nuw = self.nuw{i}{ind};
                         wordLengths(it) = length(replab.fp.Letters.compose(w, -fliplr(nuw)));
                     end
-                    % Apply a permutation that stays in the coset but
+                    % Apply a permutation so as to stays in the coset but
                     % yields a shorter word at this stage
                     bestIt = find(wordLengths == min(wordLengths), 1);
-                    cyclePerm = 1:length(g);
-                    cyclePerm(cosetChain.Delta{j}) = cosetChain.Delta{j}([bestIt:end, 1:bestIt-1]);
-                    g = g(cyclePerm);
-                    rep = rep(cyclePerm);
+                    Uj = cosetChain.U{j};
+                    u = Uj(:, bestIt)';
+                    g = g(u);
+                    rep = rep(u);
+                    self.word(rep);
                     b = g(beta);
                 end
                 ind = self.iOrbit(b,i);

--- a/src/+replab/+laws/CosetLaws.m
+++ b/src/+replab/+laws/CosetLaws.m
@@ -1,0 +1,22 @@
+classdef CosetLaws < replab.laws.FiniteSetLaws
+
+    methods
+
+        function self = CosetLaws(T)
+            self@replab.laws.FiniteSetLaws(T);
+        end
+
+    end
+
+    methods
+
+        function law_factorize_coset_representative_(self)
+            [l, r] = self.T.factorizeShortRepresentativeLetters;
+            r1 = self.T.parent.imageLetters(l);
+            self.T.parent.assertEqv(r, r1);
+            assertTrue(self.T.contains(r));
+        end
+
+    end
+
+end

--- a/src/+replab/+laws/FiniteSetLaws.m
+++ b/src/+replab/+laws/FiniteSetLaws.m
@@ -1,0 +1,23 @@
+classdef FiniteSetLaws < replab.laws.DomainLaws
+
+    methods
+
+        function self = FiniteSetLaws(T)
+            self@replab.laws.DomainLaws(T);
+        end
+
+    end
+
+    methods % Laws
+
+        function law_set_contains_representative_(self)
+            assertTrue(self.T.contains(self.T.representative));
+        end
+
+        function law_set_contains_random_element_T(self, t)
+            assertTrue(self.T.contains(t));
+        end
+
+    end
+
+end

--- a/src/+replab/+laws/LeftCosetsLaws.m
+++ b/src/+replab/+laws/LeftCosetsLaws.m
@@ -5,36 +5,51 @@ classdef LeftCosetsLaws < replab.Laws
         G % (`+replab.FiniteGroup`): Group
         H % (`+replab.FiniteGroup`): Subgroup
     end
+
     methods
+
         function self = LeftCosetsLaws(L)
             self.L = L;
             self.G = L.group;
             self.H = L.subgroup;
         end
+
     end
+
     methods
+
+        function l = laws_random_coset(self)
+            g = self.G.sample;
+            lc = self.H.leftCoset(g);
+            l = lc.laws;
+        end
+
         function law_transversal_representatives_are_canonical_(self)
             T = self.L.transversal;
             for i = 1:length(T)
-                assertEqual(T{i}, self.L.cosetRepresentative(T{i}));
+                self.G.assertEqv(T{i}, self.L.cosetRepresentative(T{i}));
             end
         end
+
         function law_coset_representative_is_stable_G(self, g)
             r1 = self.L.cosetRepresentative(g);
             r2 = self.L.cosetRepresentative(r1);
-            assertEqual(r1, r2);
+            self.G.assertEqv(r1, r2);
         end
 
         function law_coset_representatives_are_unique_GH(self, g, h)
             gh = self.G.compose(g, h);
-            assertEqual(self.L.cosetRepresentative(g), self.L.cosetRepresentative(gh));
+            self.G.assertEqv(self.L.cosetRepresentative(g), self.L.cosetRepresentative(gh));
         end
+
         function law_transversal_size_(self)
             assertEqual(length(self.L.transversal), double(self.G.order/self.H.order));
         end
+
         function morphismLaws = laws_leftAction(self)
             morphismLaws = replab.laws.FiniteMorphismLaws(self.L.leftAction);
         end
+
     end
 
 end

--- a/src/+replab/+laws/RightCosetsLaws.m
+++ b/src/+replab/+laws/RightCosetsLaws.m
@@ -18,22 +18,28 @@ classdef RightCosetsLaws < replab.Laws
 
     methods
 
+        function l = laws_random_coset(self)
+            g = self.G.sample;
+            rc = self.H.rightCoset(g);
+            l = rc.laws;
+        end
+
         function law_transversal_representatives_are_canonical_(self)
             T = self.R.transversal;
             for i = 1:length(T)
-                assertEqual(T{i}, self.R.cosetRepresentative(T{i}));
+                self.G.assertEqv(T{i}, self.R.cosetRepresentative(T{i}));
             end
         end
 
         function law_canonical_representative_is_stable_G(self, g)
             r1 = self.R.cosetRepresentative(g);
             r2 = self.R.cosetRepresentative(r1);
-            assertEqual(r1, r2);
+            self.G.assertEqv(r1, r2);
         end
 
         function law_canonical_representatives_are_unique_HG(self, h, g)
             hg = self.G.compose(h, g);
-            assertEqual(self.R.cosetRepresentative(g), self.R.cosetRepresentative(hg));
+            self.G.assertEqv(self.R.cosetRepresentative(g), self.R.cosetRepresentative(hg));
         end
 
         function law_transversal_size_(self)

--- a/src/+replab/+mrp/Factorization.m
+++ b/src/+replab/+mrp/Factorization.m
@@ -9,6 +9,21 @@ classdef Factorization < replab.Obj
 
     methods
 
+        function [l, r] = factorizeRepresentativeOfLeftCoset(self, leftCoset)
+        % Returns a tentatively short word corresponding to an element of the given coset
+        %
+        % Args:
+        %   leftCoset (`+replab.LeftCoset`): Left coset subset of `.group`
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Word expressed in letters
+        %   r: group element
+        %     Chosen coset representative
+            error('Abstract');
+        end
+
         function letters = factorize(self, g)
         % Returns the letters that compose the word with the given image
         %

--- a/src/+replab/+mrp/FactorizationChain.m
+++ b/src/+replab/+mrp/FactorizationChain.m
@@ -81,6 +81,21 @@ classdef FactorizationChain < replab.mrp.Factorization
             end
         end
 
+        function [l, r] = factorizeRepresentativeOfLeftCoset(self, leftCoset)
+        % Returns a tentatively short word corresponding to an element of the given coset
+        %
+        % Args:
+        %   leftCoset (`+replab.LeftCoset`): Left coset subset of `.group`
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Word expressed in letters
+        %   r: group element
+        %     Chosen coset representative
+            [l, r] = self.chain.wordLeftCoset(leftCoset.representative, leftCoset.group.chain);
+        end
+
         function n = maximumWordLength(self)
             c = self.chain;
             n = 0;

--- a/src/+replab/+mrp/FactorizationEnumeration.m
+++ b/src/+replab/+mrp/FactorizationEnumeration.m
@@ -26,6 +26,34 @@ classdef FactorizationEnumeration < replab.mrp.Factorization
             letters = self.words{ind};
         end
 
+        function [l, r] = factorizeRepresentativeOfLeftCoset(self, leftCoset)
+        % Returns a tentatively short word corresponding to an element of the given coset
+        %
+        % Args:
+        %   leftCoset (`+replab.LeftCoset`): Left coset subset of `.group`
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Word expressed in letters
+        %   r: group element
+        %     Chosen coset representative
+            leftCosetElements = leftCoset.elements.toCell;
+            % go through coset representatives one by one
+            bestR = leftCosetElements{1};
+            bestL = self.factorize(bestR);
+            for i = 2:length(leftCosetElements)
+                candidateR = leftCosetElements{i};
+                candidateL = self.factorize(candidateR);
+                if length(candidateL) < length(bestL)
+                    bestL = candidateL;
+                    bestR = candidateR;
+                end
+            end
+            l = bestL;
+            r = bestR;
+        end
+
         function n = maximumWordLength(self)
             n = max(cellfun(@length, self.words));
         end

--- a/src/+replab/Coset.m
+++ b/src/+replab/Coset.m
@@ -7,4 +7,51 @@ classdef Coset < replab.FiniteSet
         groupChain % (`+replab.+bsgs.Chain`): Group chain with base in lexicographic order
     end
 
+    methods
+
+        function [l, r] = factorizeShortRepresentativeLetters(self)
+        % Returns a tentatively short word corresponding to an element of this coset
+        %
+        % An effort is made to identify a short word, but without optimality guarantees.
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Letters of the word representing an element of ``self``
+        %   r: element of `.group`
+        %     Represented coset element
+            error('Abstract');
+        end
+
+        function [w, r] = factorizeShortRepresentativeWord(self)
+        % Returns a tentatively short word corresponding to an element of this coset
+        %
+        % An effort is made to identify a short word, but without optimality guarantees.
+        %
+        % Returns
+        % -------
+        %   w: charstring
+        %     Word representing an element of ``self``
+        %   r: element of `.group`
+        %     Represented coset element
+            [l, r] = self.factorizeShortRepresentativeLetters;
+            w = replab.fp.Letters.print(l, self.group.names);
+        end
+
+    end
+
+    methods % Implementations
+
+        % Domain
+
+        function l = laws(self)
+            l = replab.laws.CosetLaws(self);
+        end
+
+        function b = eqv(self, lhs, rhs)
+            b = self.parent.eqv(lhs, rhs);
+        end
+
+    end
+
 end

--- a/src/+replab/LeftCoset.m
+++ b/src/+replab/LeftCoset.m
@@ -26,7 +26,7 @@ classdef LeftCoset < replab.Coset
                 parent = group.closure(element);
             end
             if group.isNormalizedBy(element)
-                l = replab.NormalCoset(group, element, parent);
+                l = replab.NormalCoset.make(group, element, parent);
                 return
             end
             chain = parent.niceMorphism.imageGroup(group).lexChain;
@@ -84,7 +84,32 @@ classdef LeftCoset < replab.Coset
                 el = self.isomorphism.imageElement(el);
             end
             el = replab.bsgs.Cosets.leftRepresentative(self.groupChain, el);
-            b = isequal(self.representative, el);
+            if ~isempty(self.isomorphism)
+                el = self.isomorphism.preimageElement(el);
+            end
+            b = self.parent.eqv(self.representative, el);
+        end
+
+        % Coset
+
+        function [l, r] = factorizeShortRepresentativeLetters(self)
+        % Returns a tentatively short word corresponding to an element of this coset
+        %
+        % An effort is made to identify a short word, but without optimality guarantees.
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Letters of the word representing an element of ``self``
+        %   r: element of `.group`
+        %     Represented coset element
+            if isa(self.group, 'replab.PermutationGroup')
+                permCoset = self;
+            else
+                permCoset = self.group.niceGroup.leftCoset(self.isomorphism.imageElement(self.representative), self.parent.niceGroup);
+            end
+            [l, r] = self.parent.niceGroup.factorization.factorizeRepresentativeOfLeftCoset(permCoset);
+            r = self.isomorphism.preimageElement(r);
         end
 
     end

--- a/src/+replab/NormalCoset.m
+++ b/src/+replab/NormalCoset.m
@@ -48,6 +48,10 @@ classdef NormalCoset < replab.LeftCoset & replab.RightCoset
             b = contains@replab.LeftCoset(self, el);
         end
 
+        function [l, r] = factorizeShortRepresentativeLetters(self)
+            [l, r] = factorizeShortRepresentativeLetters@replab.LeftCoset(self);
+        end
+
     end
 
 end

--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -58,14 +58,6 @@ classdef PermutationGroup < replab.FiniteGroup
 
     methods (Access = protected)
 
-        function f = factorization(self)
-        % Returns an object able to compute factorizations in the group generators
-        %
-        % Returns:
-        %   `+replab.+mrp.Factorization`: A factorization instance
-            f = self.cached('factorization', @() self.computeFactorization);
-        end
-
         function f = computeFactorization(self)
             f = replab.mrp.Factorization.make(self);
         end
@@ -253,6 +245,22 @@ classdef PermutationGroup < replab.FiniteGroup
 
     methods % Group internal description
 
+        function c = chain(self)
+        % Returns the stabilizer chain corresponding to this permutation group.
+        %
+        % Returns:
+        %   `+replab.+bsgs.Chain`: Stabilizer chain
+            c = self.cached('chain', @() self.computeChain);
+        end
+
+        function f = factorization(self)
+        % Returns an object able to compute factorizations in the group generators
+        %
+        % Returns:
+        %   `+replab.+mrp.Factorization`: A factorization instance
+            f = self.cached('factorization', @() self.computeFactorization);
+        end
+
         function c = lexChain(self)
         % Returns the reduced stabilizer chain corresponding to this permutation group in lexicographic order
         %
@@ -261,14 +269,6 @@ classdef PermutationGroup < replab.FiniteGroup
         % Returns:
         %   `+replab.+bsgs.Chain`: Stabilizer chain
             c = self.cached('lexChain', @() self.computeLexChain);
-        end
-
-        function c = chain(self)
-        % Returns the stabilizer chain corresponding to this permutation group.
-        %
-        % Returns:
-        %   `+replab.+bsgs.Chain`: Stabilizer chain
-            c = self.cached('chain', @() self.computeChain);
         end
 
         function c = partialChain(self)

--- a/src/+replab/RightCoset.m
+++ b/src/+replab/RightCoset.m
@@ -26,7 +26,7 @@ classdef RightCoset < replab.Coset
                 parent = group.closure(element);
             end
             if group.isNormalizedBy(element)
-                r = replab.NormalCoset(group, element, parent);
+                r = replab.NormalCoset.make(group, element, parent);
                 return
             end
             chain = parent.niceMorphism.imageGroup(group).lexChain;
@@ -88,7 +88,28 @@ classdef RightCoset < replab.Coset
                 el = self.isomorphism.imageElement(el);
             end
             el = replab.bsgs.Cosets.rightRepresentative(self.groupChain, el);
-            b = isequal(self.representative, el);
+            if ~isempty(self.isomorphism)
+                el = self.isomorphism.preimageElement(el);
+            end
+            b = self.parent.eqv(self.representative, el);
+        end
+
+        % Coset
+
+        function [l, r] = factorizeShortRepresentativeLetters(self)
+        % Returns a tentatively short word corresponding to an element of this coset
+        %
+        % An effort is made to identify a short word, but without optimality guarantees.
+        %
+        % Returns
+        % -------
+        %   l: integer(1,\*)
+        %     Letters of the word representing an element of ``self``
+        %   r: element of `.group`
+        %     Represented coset element
+            [linv, rinv] = self.group.leftCoset(self.group.inverse(self.representative), self.parent).factorizeShortRepresentativeLetters;
+            l = replab.fp.Letters.inverse(linv);
+            r = self.group.inverse(rinv);
         end
 
     end

--- a/tests/replab/bsgs/ChainWithWordsTest.m
+++ b/tests/replab/bsgs/ChainWithWordsTest.m
@@ -18,7 +18,7 @@ function test_leftCosetWord
     w2 = [1 2 1 1 2 1 2 2];
     P2 = G2.vectorFindPermutationsTo(v2, w2);
     a2long = chain2.word(P2.representative);
-    [a2, b2] = chain2.wordCoset(P2);
+    [a2, b2] = chain2.wordLeftCoset(P2.representative, P2.group.chain);
     assert(length(a2long) > length(a2));
     assert(isequal(v2, w2(b2)));
     assert(P2.contains(b2));

--- a/tests/replab/bsgs/ChainWithWordsTest.m
+++ b/tests/replab/bsgs/ChainWithWordsTest.m
@@ -1,0 +1,26 @@
+function test_suite = ChainWithWordsTest()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+
+function test_leftCosetWord
+    global passedHere
+    passedHere = passedHere + 1;
+    gens2 = {[2 3 4 5 1 6 7 8], [1 2 6 4 7 5 8 3]};
+    G2 = replab.PermutationGroup.of(gens2{:});
+    chain2 = replab.bsgs.ChainWithWords(G2, gens2);
+    chain2.sgsWordQuick;
+    chain2.setCompleted;
+
+    v2 = [1 1 1 1 2 2 2 2];
+    w2 = [1 2 1 1 2 1 2 2];
+    P2 = G2.vectorFindPermutationsTo(v2, w2);
+    a2long = chain2.word(P2.representative);
+    [a2, b2] = chain2.wordForLeftCoset(P2);
+    assert(length(a2long) > length(a2))
+    assert(isequal(v2, w2(b2)))
+end

--- a/tests/replab/bsgs/ChainWithWordsTest.m
+++ b/tests/replab/bsgs/ChainWithWordsTest.m
@@ -8,8 +8,6 @@ function test_suite = ChainWithWordsTest()
 end
 
 function test_leftCosetWord
-    global passedHere
-    passedHere = passedHere + 1;
     gens2 = {[2 3 4 5 1 6 7 8], [1 2 6 4 7 5 8 3]};
     G2 = replab.PermutationGroup.of(gens2{:});
     chain2 = replab.bsgs.ChainWithWords(G2, gens2);

--- a/tests/replab/bsgs/ChainWithWordsTest.m
+++ b/tests/replab/bsgs/ChainWithWordsTest.m
@@ -18,7 +18,7 @@ function test_leftCosetWord
     w2 = [1 2 1 1 2 1 2 2];
     P2 = G2.vectorFindPermutationsTo(v2, w2);
     a2long = chain2.word(P2.representative);
-    [a2, b2] = chain2.wordForLeftCoset(P2);
+    [a2, b2] = chain2.wordCoset(P2);
     assert(length(a2long) > length(a2))
     assert(isequal(v2, w2(b2)))
 end

--- a/tests/replab/bsgs/ChainWithWordsTest.m
+++ b/tests/replab/bsgs/ChainWithWordsTest.m
@@ -19,6 +19,7 @@ function test_leftCosetWord
     P2 = G2.vectorFindPermutationsTo(v2, w2);
     a2long = chain2.word(P2.representative);
     [a2, b2] = chain2.wordCoset(P2);
-    assert(length(a2long) > length(a2))
-    assert(isequal(v2, w2(b2)))
+    assert(length(a2long) > length(a2));
+    assert(isequal(v2, w2(b2)));
+    assert(P2.contains(b2));
 end


### PR DESCRIPTION
Adding a method to `replab.bsgs.ChainWithWords` to words that belong to a coset, without necessarily correspond to the nominal coset representative. The idea is that some elements of a coset might be much easier to express than others, and we have no guarantee on the properties of the chosen representative. The method comes with no guarantee of minimality for the word length, but at least attempts to choose the element of the coset according to this purpose.

The implementation for `RightCoset` seems incomplete at the moment (currently same method, with the flag `isRightCoset`): the words provided don't produce an element of the coset (although the permutation does belong to the coset...) I must have missed one or two inversions somewhere, but can't point it down. Any idea where this might be the case @denisrosset ?
