### PR TITLE
[WIP] equivar

### DIFF
--- a/src/+replab/Irreducible.m
+++ b/src/+replab/Irreducible.m
@@ -163,12 +163,19 @@ classdef Irreducible < replab.SubRep
 
         % Rep
 
-
+        % TODO: add other equivariant spaces
         function c = commutant(self, type)
             if nargin < 2 || isempty(type) || strcmp(type, 'double/sparse')
                 type = 'double';
             end
             c = self.cached(['commutant_' type], @() self.irreducibleEquivariantFrom(self,  'special', 'commutant', 'type', type));
+        end
+
+        function c = sesquilinearInvariant(self, type)
+            if nargin < 2 || isempty(type) || strcmp(type, 'double/sparse')
+                type = 'double';
+            end
+            c = self.cached(['sesquilinearInvariant_' type], @() self.irreducibleEquivariantFrom(self,  'special', 'sesquilinear', 'type', type));
         end
 
          % SubRep

--- a/src/+replab/IrreducibleEquivariant.m
+++ b/src/+replab/IrreducibleEquivariant.m
@@ -265,11 +265,13 @@ classdef IrreducibleEquivariant < replab.SubEquivariant
                     parent = repR.parent.commutant(args.type);
                   case 'hermitian'
                     parent = repR.parent.hermitianInvariant(args.type);
+                  case 'antilinear'
+                    parent = repR.parent.antilinearInvariant(args.type);
+                  case 'sesquilinear'
+                    parent = repR.parent.sesquilinearInvariant(args.type);
                   case 'trivialRows'
                     parent = repR.parent.equivariantFrom(repC.parent, 'type', args.type);
                   case 'trivialCols'
-                    parent = repR.parent.equivariantFrom(repC.parent, 'type', args.type);
-                  case ''
                     parent = repR.parent.equivariantFrom(repC.parent, 'type', args.type);
                   otherwise
                     error('Invalid special structure');

--- a/src/+replab/equivar.m
+++ b/src/+replab/equivar.m
@@ -2,16 +2,17 @@ classdef equivar < replab.Str
 % Describes an equivariant map
 
     properties (SetAccess = protected)
+        field % ('R', 'C'): Field
         repR % (`.Rep`): Row representation
         repC % (`.Rep`): Column representation
         special % ('', 'symmetric', 'hermitian'): Type of equivariant variable
-        blocks % (cell(1,\*) of sdpvar(\*,\*)): Matrix blocks
         equivariant % (`.IrreducibleEquivariant`): Irreducible equivariant space
+        blocks % (cell(\*,\*) of sdpvar(\*,\*)): Matrix blocks
     end
 
     methods
 
-        function self = equivar(repR, repC, special, blocks, equivariant)
+        function self = equivar(repR, repC, special, equivariant, blocks)
             if nargin < 3
                 special = '';
             end
@@ -48,12 +49,69 @@ classdef equivar < replab.Str
                 end
             end
             assert(repR.group == repC.group, 'Both representations must be defined over the same group');
-            if isempty(blocks)
-                assert(~isempty(special), 'TODO: allow generic equivar');
+            assert(repR.field == repC.field, 'Both representations must be defined over the same field');
+            field = repR.field;
+            if isempty(equivariant)
+                switch special
+                  case 'symmetric'
+                    equivariant = repR.decomposition.sesquilinearInvariant;
+                  case 'hermitian'
+                    equivariant = repR.decomposition.sesquilinearInvariant;
+                  case ''
+                    equivariant = repR.decomposition.equivariantFrom(repC.decomposition);
+                end
             end
+            if isempty(blocks)
+                B = equivariant.blocks;
+                n1 = size(B, 1);
+                n2 = size(B, 2);
+                blocks = cell(n1, n2);
+                if isempty(special)
+                    if field == 'R'
+                        args = {'full'};
+                    else
+                        args = {'full' 'complex'};
+                    end
+                    for i = 1:size(B, 1)
+                        for j = 1:size(B, 2)
+                            b = B{i,j};
+                            blocks{i,j} = sdpvar(b.repR.multiplicity, b.repC.multiplicity, args{:});
+                        end
+                    end
+                else
+                    if field == 'R'
+                        args = {'symmetric'};
+                    else
+                        args = {'hermitian' 'complex'};
+                    end
+                    assert(n1 == n2);
+                    assert(all(all(equivariant.nonZeroBlocks == logical(eye(n1)))));
+                    for i = 1:n1
+                        b = B{i,i};
+                        m = b.repR.multiplicity;
+                        blocks{i,i} = sdpvar(m, m, args{:});
+                    end
+                end
+            end
+            self.field = field;
             self.repR = repR;
             self.repC = repC;
             self.special = special;
+            self.equivariant = equivariant;
+            self.blocks = blocks;
+        end
+
+        function C = sdp(self)
+        % Returns the YALMIP constraint that this equivar is semidefinite positive
+        %
+        % This expands the SDP constraint in the block-diagonal basis
+            C = arrayfun(@(i) self.blocks{i,i} >= 0, 1:size(self.blocks, 1), 'uniform', 0);
+            C = horzcat(C{:});
+        end
+
+        function s = sdpvar(self)
+        % Returns the matrix corresponding to this equivar, in the original basis
+            error('TODO');
         end
 
     end


### PR DESCRIPTION
This starts the work on a generic equivariant sdpvar implementation.

Currently, `IrreducibleEquivariant` has some bugs that need to be squashed before continuing.

```
rep = replab.S(3).naturalRep.tensorPower(2)
rep = 
Orthogonal tensor representation
          dimension: 9
divisionAlgebraName: []
              field: 'R'
              group: Symmetric group acting on 3 elements
          isUnitary: true
          factor(1): Orthogonal reducible representation
          factor(2): Orthogonal reducible representation

>> rep.decomposition.sesquilinearInvariant
ans = 
9 x 9 equivariant matrices over R
 blockColSize: [2, 1, 6]
 blockRowSize: [2, 1, 6]
       blocks: 3 x 3 cell
        field: 'R'
        group: Symmetric group acting on 3 elements
           nC: 9
           nR: 9
nonZeroBlocks: [true, true, false; true, true, false; false, false, true]
       parent: 9 x 9 equivariant matrices over R
         repC: Orthogonal reducible representation
         repR: Orthogonal reducible representation
      special: 'sesquilinear'
>> rep.decomposition.sesquilinearInvariant.nonZeroBlocks
ans =
  3x3 logical array
   1   1   0
   1   1   0
   0   0   1
```