### PR TITLE
Adding our code of conduct in a dedicated file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+This project follows the [Typelevel Code of Conduct](https://typelevel.org/conduct.html), reproduced here below for ease of reference.
+
+
+# Code of Conduct
+
+RepLAB is dedicated to providing a harassment-free community for everyone, regardless of gender or anything to do with it (identity, history, expression, non-binary gender, etc.), sexual orientation, disability, physical appearance, body size, race, religion, and programming background. We do not tolerate harassment of community participants in any form, and sexual language and imagery is not appropriate for any community activity. Community participants violating these rules may be sanctioned or expelled from the community at the discretion of the community organizers.
+
+RepLAB is dedicated to providing a harassment-free community for everyone, regardless of gender or anything to do with it (identity, history, expression, non-binary gender, etc.), sexual orientation, disability, physical appearance, body size, race, religion, and programming background. We do not tolerate harassment of community participants in any form, and sexual language and imagery is not appropriate for any community activity. Community participants violating these rules may be sanctioned or expelled from the community at the discretion of the community organizers.
+
+Harassment includes offensive comments related to gender or anything to do with it (identity, history, expression, non-binary gender, etc.), sexual orientation, disability, physical appearance, body size, race, religion, programming experience or background, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of community activities, spaces, or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+All participants in the community and community-associated activities are also subject to the anti-harassment policy. In particular, participants and community organizers should not use sexualized images, activities, or other material.
+
+If a participant engages in harassing behavior, the community organizers may take any action they deem appropriate, including warning the offender or expulsion from the community.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the community staff immediately. A contact address can be found here.
+
+Community staff will be happy to help participants contact local law enforcement or otherwise assist those experiencing harassment to feel safe. We value your participation.
+
+We expect participants to follow these rules at all RepLAB-supported venues –including online venues– and social events associated with Typelevel. These venues include but are not necessarily limited to:
+
+   - All GitHub repositories and comments under the RepLAB organization
+   - All Gitter channels under the RepLAB organization,
+   - The #replab IRC channel on Freenode,
+   - The RepLAB Google Group, and
+   - All conferences organized by the RepLAB organization.
+
+If you have any questions or concerns, please contact a member of the community staff, such as:
+
+   - Denis Rosset
+   - Jean-Daniel Bancal
+   - Any other members of the RepLAB organization.


### PR DESCRIPTION
We have a code of conduct (c.f. website), but it does not appear on the gihub side. Adding here a dedicated file following github's expected filename. @denisrosset feel free to merge if that is fine with you!