### PR TITLE
Warmup Octave before tests

### DIFF
--- a/src/+replab/+compat/warmup.m
+++ b/src/+replab/+compat/warmup.m
@@ -1,0 +1,15 @@
+function warmup
+% Loads and uses a few key RepLAB classes to warmup Octave
+%
+% In Octave 6.1.0 and 6.3.0, we noticed that running ``replab_runtests`` right after ``replab_init``
+% led to test failures (due to Octave mishandling ``Access=protected`` rules).
+%
+% However, loading and using the affected classes before running the test suite corrects the problem.
+%
+% This is what we do here.
+    G = replab.PermutationGroup.of([2 1 3 4], [1 2 4 3]);
+    G.abelianInvariants;
+    h = [2 3 4 1];
+    L = G.leftCoset(h);
+    r = L.representative;
+end

--- a/src/+replab/+compat/warmup.m
+++ b/src/+replab/+compat/warmup.m
@@ -7,6 +7,7 @@ function warmup
 % However, loading and using the affected classes before running the test suite corrects the problem.
 %
 % This is what we do here.
+    rehash;
     G = replab.PermutationGroup.of([2 1 3 4], [1 2 4 3]);
     G.abelianInvariants;
     h = [2 3 4 1];

--- a/src/replab_runtests.m
+++ b/src/replab_runtests.m
@@ -20,7 +20,7 @@ function result = replab_runtests(varargin)
 
     % Parse the arguments
     args = struct('slowtests', true, 'doctests', true, 'notebooks', true, 'withCoverage', false);
-    [args, restArgs] = replab.util.populateStruct(args, varargin);
+    args = replab.util.populateStruct(args, varargin);
 
     % Make sure we are in the current path
     initialPath = pwd;

--- a/src/replab_runtests.m
+++ b/src/replab_runtests.m
@@ -13,10 +13,15 @@ function result = replab_runtests(varargin)
 % Results:
 %     logical: True if all tests passed.
 
+    if replab.compat.isOctave
+        % warm up Octave before testing
+        replab.compat.warmup;
+    end
+
     % Parse the arguments
     args = struct('slowtests', true, 'doctests', true, 'notebooks', true, 'withCoverage', false);
-    [args, restArgs] = replab.util.populateStruct(args, varargin);    
-    
+    [args, restArgs] = replab.util.populateStruct(args, varargin);
+
     % Make sure we are in the current path
     initialPath = pwd;
     [pathStr, name, extension] = fileparts(which(mfilename));


### PR DESCRIPTION
This avoids Octave failing tests because the required classes have not been used before.