### PR TITLE
Fix typo collapse_helper.js

### DIFF
--- a/sphinx/_static/js/collapse_helper.js
+++ b/sphinx/_static/js/collapse_helper.js
@@ -19,7 +19,7 @@ var processAnchors = () => {
     }
 };
 
-val watchAnchorClicks = () => {
+var watchAnchorClicks = () => {
     $(document).ready(function() {
 	$('a').click(function(){
 	    target = $( this ).attr('href');


### PR DESCRIPTION
@jdbancal Making a PR as "collapse_helper.js" should be corrected in all Sphinx repositories