### PR TITLE
fix: correct PermutationGroup.normalClosure

### DIFF
--- a/src/+replab/PermutationGroup.m
+++ b/src/+replab/PermutationGroup.m
@@ -528,14 +528,19 @@ classdef PermutationGroup < replab.FiniteGroup
             if isa(rhs, 'replab.FiniteGroup')
                 toCheck = rhs.generators;
                 chain = rhs.chain;
+                generators = rhs.generators;
             else
                 toCheck = {rhs};
+                if ~self.type.isIdentity(rhs)
+                    generators = {rhs};
+                else
+                    generators = cell(1, 0);
+                end
                 chain = replab.bsgs.Chain.make(length(rhs), {rhs});
             end
             chain = chain.mutableCopy;
             % Algorithm, see NORMALCLOSURE, p. 75 of Derek Holt Handbook of CGT, but we do not
             % use random elements
-            generators = {};
             while ~isempty(toCheck)
                 rhsg = toCheck{end};
                 toCheck = toCheck(1:end-1);

--- a/tests/issues/Issue635Test.m
+++ b/tests/issues/Issue635Test.m
@@ -1,0 +1,15 @@
+function test_suite = Issue635Test()
+    disp(['Setting up tests in ', mfilename()]);
+    try
+        test_functions = localfunctions();
+    catch
+    end
+    initTestSuite;
+end
+
+function test_issue()
+    S3 = replab.S(3);
+    rep = S3.signRep;
+    G = rep.kernel; % G should be C(3)
+    assertFalse(G.isTrivial); % fails
+end


### PR DESCRIPTION
The method PermutationGroup.normalClosure did not return a correct set of generators.
It did omit the generators of the object of which we construct the closure.
We fix the issue and add a test.

Fixes #635